### PR TITLE
rename-to-oarcle-cd

### DIFF
--- a/cd-scripts/config.yaml
+++ b/cd-scripts/config.yaml
@@ -86,4 +86,4 @@ chains:
 ibc:
   relayer:
     docker_image: noislabs/nois-relayer
-  version: nois-v1
+  version: nois-v2


### PR DESCRIPTION
This is not deployed yet because it needs a new tag release to pull the code from 