### PR TITLE
Reduce storage key length for submissions_order

### DIFF
--- a/contracts/nois-drand/src/contract.rs
+++ b/contracts/nois-drand/src/contract.rs
@@ -19,12 +19,12 @@ use crate::msg::{
 };
 use crate::state::{
     Bot, Config, QueriedBeacon, QueriedBot, StoredSubmission, VerifiedBeacon, ALLOWLIST, BEACONS,
-    BOTS, CONFIG, SUBMISSIONS, SUBMISSIONS_ORDER,
+    BOTS, CONFIG, ORDERS, SUBMISSIONS,
 };
 
 /// Constant defining how many submissions per round will be rewarded
-const NUMBER_OF_INCENTIVES_PER_ROUND: u32 = 6;
-const NUMBER_OF_SUBMISSION_VERIFICATION_PER_ROUND: u32 = 3;
+const NUMBER_OF_INCENTIVES_PER_ROUND: u16 = 6;
+const NUMBER_OF_SUBMISSION_VERIFICATION_PER_ROUND: u16 = 3;
 /// Point system for rewarding submisisons.
 ///
 /// We use small integers here which are later multiplied with a constant to
@@ -133,7 +133,7 @@ fn query_beacons(
 
 // Query submissions by round
 fn query_submissions(deps: Deps, round: u64) -> StdResult<SubmissionsResponse> {
-    let prefix = SUBMISSIONS_ORDER.prefix(round);
+    let prefix = ORDERS.prefix(round);
 
     let submission_addresses: Vec<Addr> = prefix
         .range(deps.storage, None, None, Order::Ascending)
@@ -267,7 +267,7 @@ fn execute_add_round(
     // Get the number of submission before this one.
     // The submissions are indexed 0-based, i.e. the number of elements is
     // the last index + 1 or 0 if no last index exists.
-    let submissions_count = match SUBMISSIONS_ORDER
+    let submissions_count = match ORDERS
         .prefix(round)
         .keys(deps.storage, None, None, Order::Descending)
         .next()
@@ -336,7 +336,7 @@ fn execute_add_round(
         },
     )?;
 
-    SUBMISSIONS_ORDER.save(deps.storage, (round, submissions_count), &info.sender)?;
+    ORDERS.save(deps.storage, (round, submissions_count), &info.sender)?;
 
     let mut attributes = vec![
         Attribute::new(ATTR_ROUND, round.to_string()),

--- a/contracts/nois-drand/src/state.rs
+++ b/contracts/nois-drand/src/state.rs
@@ -69,13 +69,13 @@ pub struct StoredSubmission {
 /// An entry of this map looks like (round, drand_bot_addr) =>  time
 pub const SUBMISSIONS: Map<(u64, &Addr), StoredSubmission> = Map::new("submissions");
 
-/// A map from (round, index) to bot address. This is used when
-/// sorted submissions are needed.
+/// A map from (round, index) to bot address, storing one entry per submission.
+/// This is used when sorted submissions are needed.
 ///
 /// The `index` values are 0-based. So the `n`th submission has index
 /// n-1 here as well as in the response array in `SubmissionsResponse`.
 /// An entry of this map looks like (round, 1) =>  drand_bot_addr ; Second fastest bot
-pub const SUBMISSIONS_ORDER: Map<(u64, u32), Addr> = Map::new("submissions_order");
+pub const ORDERS: Map<(u64, u16), Addr> = Map::new("orders");
 
 /// The bot type for the state. We don't need the address here
 /// since this is stored in the storage key.


### PR DESCRIPTION
This includes a subset of the changes from #179 which are easy wins that are not risky