### PR TITLE
Add payment contract factory to gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,7 @@ dependencies = [
 name = "nois-payment"
 version = "0.11.0"
 dependencies = [
+ "anything",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
+ "hex",
  "nois",
  "serde",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "cw-storage-plus",
  "drand-common",
  "nois",
+ "nois-payment",
  "nois-protocol",
  "serde",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ dependencies = [
  "nois-payment",
  "nois-protocol",
  "serde",
+ "sha2 0.10.6",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,7 @@ dependencies = [
  "nois-drand",
  "nois-gateway",
  "nois-icecube",
+ "nois-payment",
  "nois-proxy",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
+name = "anything"
+version = "0.11.0"
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/nois-gateway/Cargo.toml
+++ b/contracts/nois-gateway/Cargo.toml
@@ -26,5 +26,6 @@ cosmwasm-schema = { version = "1.2.3" }
 cw-storage-plus = { version = "1.0.0" }
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
+sha2 = "0.10.6"
 
 [dev-dependencies]

--- a/contracts/nois-gateway/Cargo.toml
+++ b/contracts/nois-gateway/Cargo.toml
@@ -20,7 +20,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 nois-protocol = { path = "../../packages/nois-protocol"}
 drand-common = { path = "../../packages/drand-common" }
 nois.workspace = true
-cosmwasm-std = { version = "1.2.3", features = ["iterator", "ibc3"] }
+cosmwasm-std = { version = "1.2.3", features = ["iterator", "ibc3", "cosmwasm_1_2"] }
 cosmwasm-schema = { version = "1.2.3" }
 cw-storage-plus = { version = "1.0.0" }
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/nois-gateway/Cargo.toml
+++ b/contracts/nois-gateway/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
+nois-payment = { path = "../../contracts/nois-payment"}
 nois-protocol = { path = "../../packages/nois-protocol"}
 drand-common = { path = "../../packages/drand-common" }
 nois.workspace = true

--- a/contracts/nois-gateway/src/contract.rs
+++ b/contracts/nois-gateway/src/contract.rs
@@ -31,6 +31,7 @@ pub fn instantiate(
         price,
         manager,
         payment_code_id,
+        payment_initial_funds,
         sink,
     } = msg;
 
@@ -44,6 +45,7 @@ pub fn instantiate(
         manager,
         price,
         payment_code_id,
+        payment_initial_funds,
         sink,
     };
     CONFIG.save(deps.storage, &config)?;
@@ -170,7 +172,7 @@ pub fn ibc_channel_connect(
         msg: to_binary(&nois_payment::msg::InstantiateMsg {
             sink: config.sink.into(),
         })?,
-        funds: vec![],
+        funds: vec![config.payment_initial_funds],
         salt,
     };
 
@@ -389,7 +391,8 @@ fn execute_set_config(
         drand,
         price,
         payment_code_id,
-        sink: config.sink, // TODO: make updatable?
+        payment_initial_funds: config.payment_initial_funds, // TODO: make updatable?
+        sink: config.sink,                                   // TODO: make updatable?
     };
 
     CONFIG.save(deps.storage, &new_config)?;
@@ -453,12 +456,17 @@ mod tests {
     const ROUND3: u64 = 830;
     const ROUND4: u64 = 840;
 
+    fn payment_initial() -> Coin {
+        coin(2_000000, "unois")
+    }
+
     fn setup() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
         let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            payment_initial_funds: payment_initial(),
             sink: SINK.to_string(),
         };
         let info = mock_info(CREATOR, &[]);
@@ -680,6 +688,7 @@ mod tests {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            payment_initial_funds: payment_initial(),
             sink: SINK.to_string(),
         };
         let info = mock_info("creator", &[]);
@@ -696,6 +705,7 @@ mod tests {
                 manager: Addr::unchecked(MANAGER),
                 price: Coin::new(1, "unois"),
                 payment_code_id: PAYMENT,
+                payment_initial_funds: payment_initial(),
                 sink: Addr::unchecked(SINK),
             }
         );
@@ -709,6 +719,7 @@ mod tests {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
             payment_code_id: 654321,
+            payment_initial_funds: payment_initial(),
             sink: SINK.to_string(),
         };
         let info = mock_info("creator", &[]);
@@ -732,6 +743,7 @@ mod tests {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            payment_initial_funds: payment_initial(),
             sink: SINK.to_string(),
         };
         let info = mock_info("creator", &[]);
@@ -770,6 +782,7 @@ mod tests {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            payment_initial_funds: payment_initial(),
             sink: SINK.to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -813,6 +826,7 @@ mod tests {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            payment_initial_funds: payment_initial(),
             sink: SINK.to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -976,6 +990,7 @@ mod tests {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            payment_initial_funds: payment_initial(),
             sink: SINK.to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();

--- a/contracts/nois-gateway/src/contract.rs
+++ b/contracts/nois-gateway/src/contract.rs
@@ -28,6 +28,7 @@ pub fn instantiate(
         drand: None,
         manager,
         price: msg.price,
+        payment_code_id: msg.payment_code_id,
     };
     CONFIG.save(deps.storage, &config)?;
     Ok(Response::default())
@@ -57,7 +58,8 @@ pub fn execute(
             manager,
             price,
             drand_addr,
-        } => execute_set_config(deps, info, env, manager, price, drand_addr),
+            payment_code_id,
+        } => execute_set_config(deps, info, env, manager, price, drand_addr, payment_code_id),
     }
 }
 
@@ -264,6 +266,7 @@ fn execute_set_config(
     manager: Option<String>,
     price: Option<Coin>,
     drand: Option<String>,
+    payment_code_id: Option<u64>,
 ) -> Result<Response, ContractError> {
     let config = CONFIG.load(deps.storage)?;
 
@@ -282,10 +285,13 @@ fn execute_set_config(
         Some(pr) => pr,
         None => config.price,
     };
+    let payment_code_id = payment_code_id.unwrap_or(config.payment_code_id);
+
     let new_config = Config {
         manager,
         drand,
         price,
+        payment_code_id,
     };
 
     CONFIG.save(deps.storage, &new_config)?;
@@ -312,6 +318,7 @@ mod tests {
 
     const CREATOR: &str = "creator";
     const MANAGER: &str = "boss";
+    const PAYMENT: u64 = 33;
 
     // Consecutive timestamps for the rounds 810, 820, 830, 840
     const AFTER1: Timestamp = Timestamp::from_seconds(1677687627 - 1);
@@ -328,6 +335,7 @@ mod tests {
         let msg = InstantiateMsg {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
+            payment_code_id: PAYMENT,
         };
         let info = mock_info(CREATOR, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -498,6 +506,7 @@ mod tests {
         let msg = InstantiateMsg {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
+            payment_code_id: PAYMENT,
         };
         let info = mock_info("creator", &[]);
         let env = mock_env();
@@ -511,7 +520,8 @@ mod tests {
             ConfigResponse {
                 drand: None,
                 manager: Addr::unchecked(MANAGER),
-                price: Coin::new(1, "unois")
+                price: Coin::new(1, "unois"),
+                payment_code_id: PAYMENT,
             }
         );
     }
@@ -528,6 +538,7 @@ mod tests {
         let msg = InstantiateMsg {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
+            payment_code_id: PAYMENT,
         };
         instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -547,6 +558,7 @@ mod tests {
             manager: None,
             price: None,
             drand_addr: Some(DRAND.to_string()),
+            payment_code_id: None,
         };
         let _res = execute(deps.as_mut(), mock_env(), mock_info(MANAGER, &[]), msg).unwrap();
 
@@ -568,6 +580,7 @@ mod tests {
         let msg = InstantiateMsg {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
+            payment_code_id: PAYMENT,
         };
         instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -578,6 +591,7 @@ mod tests {
             manager: None,
             price: None,
             drand_addr: Some(DRAND.to_string()),
+            payment_code_id: None,
         };
         let _res = execute(deps.as_mut(), mock_env(), mock_info(MANAGER, &[]), msg).unwrap();
 
@@ -728,6 +742,7 @@ mod tests {
         let msg = InstantiateMsg {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
+            payment_code_id: PAYMENT,
         };
         instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -738,6 +753,7 @@ mod tests {
             manager: None,
             price: None,
             drand_addr: Some(DRAND.to_string()),
+            payment_code_id: None,
         };
         let _res = execute(deps.as_mut(), mock_env(), mock_info(MANAGER, &[]), msg).unwrap();
 

--- a/contracts/nois-gateway/src/contract.rs
+++ b/contracts/nois-gateway/src/contract.rs
@@ -309,8 +309,8 @@ fn receive_request_beacon(
     let config = CONFIG.load(deps.storage)?;
 
     let Coin { amount, denom } = config.price;
-    let amount_burn = amount.mul_ceil((50u128, 100)); // 50%
-    let amount_relayer = amount.mul_ceil((5u128, 100)); // 5%
+    let amount_burn = amount.mul_floor((50u128, 100)); // 50%
+    let amount_relayer = amount.mul_floor((5u128, 100)); // 5%
     let amount_rest = amount - amount_burn - amount_relayer; // 45%
 
     let msg = WasmMsg::Execute {

--- a/contracts/nois-gateway/src/contract.rs
+++ b/contracts/nois-gateway/src/contract.rs
@@ -238,7 +238,7 @@ fn receive_request_beacon(
     } = router.route(deps.branch(), env, channel_id.clone(), after, origin)?;
 
     // Pay time
-    let abc = PAYMENT_ADDRESSES.load(deps.storage, &channel_id)?;
+    let payment_contract = PAYMENT_ADDRESSES.load(deps.storage, &channel_id)?;
 
     let config = CONFIG.load(deps.storage)?;
 
@@ -248,7 +248,7 @@ fn receive_request_beacon(
     let amount_rest = amount - amount_burn - amount_relayer; // 45%
 
     let msg = WasmMsg::Execute {
-        contract_addr: abc.into(),
+        contract_addr: payment_contract.into(),
         msg: to_binary(&nois_payment::msg::ExecuteMsg::Pay {
             burn: Coin::new(amount_burn.u128(), &denom),
             relayer: (relayer.into(), Coin::new(amount_relayer.u128(), &denom)),

--- a/contracts/nois-gateway/src/contract.rs
+++ b/contracts/nois-gateway/src/contract.rs
@@ -29,9 +29,14 @@ pub fn instantiate(
         price,
         manager,
         payment_code_id,
+        sink,
+        community_pool,
     } = msg;
 
     let manager = deps.api.addr_validate(&manager)?;
+    let sink = deps.api.addr_validate(&sink)?;
+    let community_pool = deps.api.addr_validate(&community_pool)?;
+
     ensure_code_id_exists(deps.as_ref(), payment_code_id)?;
 
     let config = Config {
@@ -39,6 +44,8 @@ pub fn instantiate(
         manager,
         price,
         payment_code_id,
+        sink,
+        community_pool,
     };
     CONFIG.save(deps.storage, &config)?;
     Ok(Response::default())
@@ -146,17 +153,13 @@ pub fn ibc_channel_connect(
     }
     // TODO: store _address
 
-    // FIXME: add to config
-    let sink_address = "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt".to_string();
-    let community_pool_address = "nois1uw8c69maprjq5ure7x80x9nauasrn7why5dfwd".to_string();
-
     let msg = WasmMsg::Instantiate2 {
         admin: Some(env.contract.address.into()), // Only gateway can update the contracts it created
         code_id: config.payment_code_id,
         label: format!("For {chan_id}"),
         msg: to_binary(&nois_payment::msg::InstantiateMsg {
-            sink: sink_address,
-            community_pool: community_pool_address,
+            sink: config.sink.into(),
+            community_pool: config.community_pool.into(),
         })?,
         funds: vec![],
         salt,
@@ -343,6 +346,8 @@ fn execute_set_config(
         drand,
         price,
         payment_code_id,
+        sink: config.sink,                     // TODO: make updatable?
+        community_pool: config.community_pool, // TODO: make updatable?
     };
 
     CONFIG.save(deps.storage, &new_config)?;
@@ -394,6 +399,8 @@ mod tests {
     const MANAGER: &str = "boss";
     const PAYMENT: u64 = 33;
     const PAYMENT2: u64 = 37;
+    const SINK: &str = "sink";
+    const COMMUNOTY_POOL: &str = "community_pool";
 
     // Consecutive timestamps for the rounds 810, 820, 830, 840
     const AFTER1: Timestamp = Timestamp::from_seconds(1677687627 - 1);
@@ -411,6 +418,8 @@ mod tests {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            sink: SINK.to_string(),
+            community_pool: COMMUNOTY_POOL.to_string(),
         };
         let info = mock_info(CREATOR, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -631,6 +640,8 @@ mod tests {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            sink: SINK.to_string(),
+            community_pool: COMMUNOTY_POOL.to_string(),
         };
         let info = mock_info("creator", &[]);
         let env = mock_env();
@@ -646,6 +657,8 @@ mod tests {
                 manager: Addr::unchecked(MANAGER),
                 price: Coin::new(1, "unois"),
                 payment_code_id: PAYMENT,
+                sink: Addr::unchecked(SINK),
+                community_pool: Addr::unchecked(COMMUNOTY_POOL),
             }
         );
     }
@@ -658,6 +671,8 @@ mod tests {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
             payment_code_id: 654321,
+            sink: SINK.to_string(),
+            community_pool: COMMUNOTY_POOL.to_string(),
         };
         let info = mock_info("creator", &[]);
         let env = mock_env();
@@ -680,6 +695,8 @@ mod tests {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            sink: SINK.to_string(),
+            community_pool: COMMUNOTY_POOL.to_string(),
         };
         let info = mock_info("creator", &[]);
         let env = mock_env();
@@ -717,6 +734,8 @@ mod tests {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            sink: SINK.to_string(),
+            community_pool: COMMUNOTY_POOL.to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -759,6 +778,8 @@ mod tests {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            sink: SINK.to_string(),
+            community_pool: COMMUNOTY_POOL.to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -921,6 +942,8 @@ mod tests {
             manager: MANAGER.to_string(),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            sink: SINK.to_string(),
+            community_pool: COMMUNOTY_POOL.to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 

--- a/contracts/nois-gateway/src/contract.rs
+++ b/contracts/nois-gateway/src/contract.rs
@@ -155,8 +155,8 @@ pub fn ibc_channel_connect(
         code_id: config.payment_code_id,
         label: format!("For {chan_id}"),
         msg: to_binary(&nois_payment::msg::InstantiateMsg {
-            nois_sink: sink_address,
-            nois_com_pool_addr: community_pool_address,
+            sink: sink_address,
+            community_pool: community_pool_address,
         })?,
         funds: vec![],
         salt,

--- a/contracts/nois-gateway/src/contract.rs
+++ b/contracts/nois-gateway/src/contract.rs
@@ -653,11 +653,7 @@ mod tests {
         format!("job {job}").into_bytes().into()
     }
 
-    // connect will run through the entire handshake to set up a proper connect and
-    // save the account (tested in detail in `proper_handshake_flow`)
-    fn connect(mut deps: DepsMut, channel_id: &str, account: impl Into<String>) {
-        let _account: String = account.into();
-
+    fn connect(mut deps: DepsMut, channel_id: &str) {
         let handshake_open = mock_ibc_channel_open_try(channel_id, APP_ORDER, IBC_APP_VERSION);
         // first we try to open with a valid handshake
         ibc_channel_open(deps.branch(), mock_env(), handshake_open).unwrap();
@@ -1248,7 +1244,7 @@ mod tests {
         let account = "acct-123";
 
         // register the channel
-        connect(deps.as_mut(), channel_id, account);
+        connect(deps.as_mut(), channel_id);
         // assign it some funds
         let funds = vec![coin(123456, "uatom"), coin(7654321, "tgrd")];
         deps.querier.update_balance(account, funds);
@@ -1303,10 +1299,9 @@ mod tests {
         let mut deps = setup();
 
         let channel_id = "channel-123";
-        let account = "acct-123";
 
         // register the channel
-        connect(deps.as_mut(), channel_id, account);
+        connect(deps.as_mut(), channel_id);
 
         // Existing channel
         let CustomerResponse { customer: address } = from_binary(
@@ -1350,10 +1345,9 @@ mod tests {
 
         const DRAND: &str = "drand_verifier_7";
         const CHANNEL_ID: &str = "the-channel";
-        let account = "acct-123";
 
         // register the channel
-        connect(deps.as_mut(), CHANNEL_ID, account);
+        connect(deps.as_mut(), CHANNEL_ID);
 
         // Set drand contract
         let msg = ExecuteMsg::SetConfig {
@@ -1433,7 +1427,6 @@ mod tests {
         let mut deps = setup();
 
         let channel_id = "channel-123";
-        let account = "acct-123";
 
         let CustomersResponse {
             customers: addresses,
@@ -1452,7 +1445,7 @@ mod tests {
         assert_eq!(addresses, vec![]);
 
         // register the channel
-        connect(deps.as_mut(), channel_id, account);
+        connect(deps.as_mut(), channel_id);
 
         let CustomersResponse {
             customers: addresses,

--- a/contracts/nois-gateway/src/contract.rs
+++ b/contracts/nois-gateway/src/contract.rs
@@ -147,8 +147,8 @@ pub fn ibc_channel_connect(
     // TODO: store _address
 
     // FIXME: add to config
-    let sink_address = "123".to_string();
-    let community_pool_address = "123".to_string();
+    let sink_address = "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt".to_string();
+    let community_pool_address = "nois1uw8c69maprjq5ure7x80x9nauasrn7why5dfwd".to_string();
 
     let msg = WasmMsg::Instantiate2 {
         admin: Some(env.contract.address.into()), // Only gateway can update the contracts it created

--- a/contracts/nois-gateway/src/contract.rs
+++ b/contracts/nois-gateway/src/contract.rs
@@ -32,12 +32,10 @@ pub fn instantiate(
         manager,
         payment_code_id,
         sink,
-        community_pool,
     } = msg;
 
     let manager = deps.api.addr_validate(&manager)?;
     let sink = deps.api.addr_validate(&sink)?;
-    let community_pool = deps.api.addr_validate(&community_pool)?;
 
     ensure_code_id_exists(deps.as_ref(), payment_code_id)?;
 
@@ -47,7 +45,6 @@ pub fn instantiate(
         price,
         payment_code_id,
         sink,
-        community_pool,
     };
     CONFIG.save(deps.storage, &config)?;
     Ok(Response::default())
@@ -172,7 +169,6 @@ pub fn ibc_channel_connect(
         label: format!("For {chan_id}"),
         msg: to_binary(&nois_payment::msg::InstantiateMsg {
             sink: config.sink.into(),
-            community_pool: config.community_pool.into(),
         })?,
         funds: vec![],
         salt,
@@ -393,8 +389,7 @@ fn execute_set_config(
         drand,
         price,
         payment_code_id,
-        sink: config.sink,                     // TODO: make updatable?
-        community_pool: config.community_pool, // TODO: make updatable?
+        sink: config.sink, // TODO: make updatable?
     };
 
     CONFIG.save(deps.storage, &new_config)?;
@@ -447,7 +442,6 @@ mod tests {
     const PAYMENT: u64 = 33;
     const PAYMENT2: u64 = 37;
     const SINK: &str = "sink";
-    const COMMUNOTY_POOL: &str = "community_pool";
 
     // Consecutive timestamps for the rounds 810, 820, 830, 840
     const AFTER1: Timestamp = Timestamp::from_seconds(1677687627 - 1);
@@ -466,7 +460,6 @@ mod tests {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: SINK.to_string(),
-            community_pool: COMMUNOTY_POOL.to_string(),
         };
         let info = mock_info(CREATOR, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -688,7 +681,6 @@ mod tests {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: SINK.to_string(),
-            community_pool: COMMUNOTY_POOL.to_string(),
         };
         let info = mock_info("creator", &[]);
         let env = mock_env();
@@ -705,7 +697,6 @@ mod tests {
                 price: Coin::new(1, "unois"),
                 payment_code_id: PAYMENT,
                 sink: Addr::unchecked(SINK),
-                community_pool: Addr::unchecked(COMMUNOTY_POOL),
             }
         );
     }
@@ -719,7 +710,6 @@ mod tests {
             price: Coin::new(1, "unois"),
             payment_code_id: 654321,
             sink: SINK.to_string(),
-            community_pool: COMMUNOTY_POOL.to_string(),
         };
         let info = mock_info("creator", &[]);
         let env = mock_env();
@@ -743,7 +733,6 @@ mod tests {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: SINK.to_string(),
-            community_pool: COMMUNOTY_POOL.to_string(),
         };
         let info = mock_info("creator", &[]);
         let env = mock_env();
@@ -782,7 +771,6 @@ mod tests {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: SINK.to_string(),
-            community_pool: COMMUNOTY_POOL.to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -826,7 +814,6 @@ mod tests {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: SINK.to_string(),
-            community_pool: COMMUNOTY_POOL.to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -990,7 +977,6 @@ mod tests {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: SINK.to_string(),
-            community_pool: COMMUNOTY_POOL.to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 

--- a/contracts/nois-gateway/src/error.rs
+++ b/contracts/nois-gateway/src/error.rs
@@ -12,6 +12,10 @@ pub enum ContractError {
     #[error("Unauthorized")]
     Unauthorized,
 
+    // Payment
+    #[error("Code ID does not exist: {code_id}")]
+    CodeIdDoesNotExist { code_id: u64 },
+
     // Jobs
     #[error("Origin data exceeds length limit.")]
     OriginTooLong,

--- a/contracts/nois-gateway/src/error.rs
+++ b/contracts/nois-gateway/src/error.rs
@@ -24,6 +24,9 @@ pub enum ContractError {
     UnauthorizedAddVerifiedRound,
 
     // IBC
+    #[error("The nois-gateway contract must be on chain B of the connection. Try swapping A and B in the channel creation.")]
+    MustBeChainB,
+
     #[error("{0}")]
     ChannelError(#[from] ChannelError),
 

--- a/contracts/nois-gateway/src/msg.rs
+++ b/contracts/nois-gateway/src/msg.rs
@@ -10,8 +10,8 @@ pub struct InstantiateMsg {
     pub manager: String,
     pub payment_code_id: u64,
     /// An amount the gateway sends to the payment contract during instantiation.
-    /// Use 0unois to diable.
-    pub payment_initial_funds: Coin,
+    /// Use None or 0unois to disable.
+    pub payment_initial_funds: Option<Coin>,
     /// Address of the Nois sink
     pub sink: String,
 }
@@ -30,6 +30,10 @@ pub enum ExecuteMsg {
         price: Option<Coin>,
         drand_addr: Option<String>,
         payment_code_id: Option<u64>,
+        /// Updates the `payment_initial_funds`. When this value is set, the config will be updated.
+        /// It is currently not possible to unset the value after it has been set before.
+        /// See https://twitter.com/simon_warta/status/1643354582494642177 for why.
+        /// To deactivate it later on, send Some(Coin::new(0, "unois")) here.
         payment_initial_funds: Option<Coin>,
     },
 }

--- a/contracts/nois-gateway/src/msg.rs
+++ b/contracts/nois-gateway/src/msg.rs
@@ -9,6 +9,9 @@ pub struct InstantiateMsg {
     pub price: Coin,
     pub manager: String,
     pub payment_code_id: u64,
+    /// An amount the gateway sends to the payment contract during instantiation.
+    /// Use 0unois to diable.
+    pub payment_initial_funds: Coin,
     /// Address of the Nois sink
     pub sink: String,
 }

--- a/contracts/nois-gateway/src/msg.rs
+++ b/contracts/nois-gateway/src/msg.rs
@@ -29,7 +29,6 @@ pub enum ExecuteMsg {
         manager: Option<String>,
         price: Option<Coin>,
         drand_addr: Option<String>,
-        payment_code_id: Option<u64>,
         /// Updates the `payment_initial_funds`. When this value is set, the config will be updated.
         /// It is currently not possible to unset the value after it has been set before.
         /// See https://twitter.com/simon_warta/status/1643354582494642177 for why.

--- a/contracts/nois-gateway/src/msg.rs
+++ b/contracts/nois-gateway/src/msg.rs
@@ -30,6 +30,7 @@ pub enum ExecuteMsg {
         price: Option<Coin>,
         drand_addr: Option<String>,
         payment_code_id: Option<u64>,
+        payment_initial_funds: Option<Coin>,
     },
 }
 

--- a/contracts/nois-gateway/src/msg.rs
+++ b/contracts/nois-gateway/src/msg.rs
@@ -11,8 +11,6 @@ pub struct InstantiateMsg {
     pub payment_code_id: u64,
     /// Address of the Nois sink
     pub sink: String,
-    /// Address of the Nois community pool
-    pub community_pool: String,
 }
 
 #[cw_serde]

--- a/contracts/nois-gateway/src/msg.rs
+++ b/contracts/nois-gateway/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Coin, HexBinary};
 
-use crate::state::Config;
+use crate::state::{Config, Customer};
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -46,10 +46,10 @@ pub enum QueryMsg {
     /// Gets basic statistics about jobs in this drand round.
     #[returns(DrandJobStatsResponse)]
     DrandJobStats { round: u64 },
-    #[returns(PaymentAddressResponse)]
-    PaymentAddress { channel_id: String },
-    #[returns(PaymentAddressesResponse)]
-    PaymentAddresses {
+    #[returns(CustomerResponse)]
+    Customer { channel_id: String },
+    #[returns(CustomersResponse)]
+    Customers {
         /// The channel ID after which to start
         start_after: Option<String>,
         limit: Option<u32>,
@@ -69,19 +69,31 @@ pub struct DrandJobStatsResponse {
 }
 
 #[cw_serde]
-pub struct QueriedPaymentAddress {
+pub struct QueriedCustomer {
     pub channel_id: String,
-    /// The address of the payment contract
-    pub address: Addr,
+    /// The payment contract address
+    pub payment: Addr,
+    /// Number of beacons requested in total
+    pub requested_beacons: u64,
+}
+
+impl QueriedCustomer {
+    pub fn new(channel_id: String, customer: Customer) -> Self {
+        Self {
+            channel_id,
+            payment: customer.payment,
+            requested_beacons: customer.requested_beacons,
+        }
+    }
 }
 
 #[cw_serde]
-pub struct PaymentAddressResponse {
-    /// The address of the payment contract
-    pub address: Option<Addr>,
+pub struct CustomerResponse {
+    /// The customer when found. None/null otherwise.
+    pub customer: Option<QueriedCustomer>,
 }
 
 #[cw_serde]
-pub struct PaymentAddressesResponse {
-    pub addresses: Vec<QueriedPaymentAddress>,
+pub struct CustomersResponse {
+    pub customers: Vec<QueriedCustomer>,
 }

--- a/contracts/nois-gateway/src/msg.rs
+++ b/contracts/nois-gateway/src/msg.rs
@@ -8,6 +8,7 @@ pub struct InstantiateMsg {
     /// The price of a randomness.
     pub price: Coin,
     pub manager: String,
+    pub payment_code_id: u64,
 }
 
 #[cw_serde]
@@ -23,6 +24,7 @@ pub enum ExecuteMsg {
         manager: Option<String>,
         price: Option<Coin>,
         drand_addr: Option<String>,
+        payment_code_id: Option<u64>,
     },
 }
 

--- a/contracts/nois-gateway/src/msg.rs
+++ b/contracts/nois-gateway/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Coin, HexBinary};
+use cosmwasm_std::{Addr, Coin, HexBinary};
 
 use crate::state::Config;
 
@@ -42,6 +42,14 @@ pub enum QueryMsg {
     /// Gets basic statistics about jobs in this drand round.
     #[returns(DrandJobStatsResponse)]
     DrandJobStats { round: u64 },
+    #[returns(PaymentAddressResponse)]
+    PaymentAddress { channel_id: String },
+    #[returns(PaymentAddressesResponse)]
+    PaymentAddresses {
+        /// The channel ID after which to start
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
 }
 
 // We define a custom struct for each query response
@@ -54,4 +62,22 @@ pub struct DrandJobStatsResponse {
     pub unprocessed: u32,
     /// Number of processed jobs
     pub processed: u32,
+}
+
+#[cw_serde]
+pub struct QueriedPaymentAddress {
+    pub channel_id: String,
+    /// The address of the payment contract
+    pub address: Addr,
+}
+
+#[cw_serde]
+pub struct PaymentAddressResponse {
+    /// The address of the payment contract
+    pub address: Option<Addr>,
+}
+
+#[cw_serde]
+pub struct PaymentAddressesResponse {
+    pub addresses: Vec<QueriedPaymentAddress>,
 }

--- a/contracts/nois-gateway/src/msg.rs
+++ b/contracts/nois-gateway/src/msg.rs
@@ -9,6 +9,10 @@ pub struct InstantiateMsg {
     pub price: Coin,
     pub manager: String,
     pub payment_code_id: u64,
+    /// Address of the Nois sink
+    pub sink: String,
+    /// Address of the Nois community pool
+    pub community_pool: String,
 }
 
 #[cw_serde]

--- a/contracts/nois-gateway/src/request_router.rs
+++ b/contracts/nois-gateway/src/request_router.rs
@@ -4,9 +4,7 @@ use cosmwasm_std::{
     to_binary, Binary, CosmosMsg, DepsMut, Env, HexBinary, IbcMsg, StdError, StdResult, Timestamp,
 };
 use drand_common::{valid_round_after, DRAND_CHAIN_HASH};
-use nois_protocol::{
-    DeliverBeaconPacket, RequestBeaconPacketAck, StdAck, DELIVER_BEACON_PACKET_LIFETIME,
-};
+use nois_protocol::{OutPacket, RequestBeaconPacketAck, StdAck, DELIVER_BEACON_PACKET_LIFETIME};
 
 use crate::{
     drand_archive::{archive_lookup, archive_store},
@@ -135,7 +133,7 @@ fn create_deliver_beacon_ibc_message(
     job: Job,
     randomness: HexBinary,
 ) -> Result<IbcMsg, StdError> {
-    let packet = DeliverBeaconPacket {
+    let packet = OutPacket::DeliverBeacon {
         randomness,
         source_id: job.source_id,
         origin: job.origin,

--- a/contracts/nois-gateway/src/state.rs
+++ b/contracts/nois-gateway/src/state.rs
@@ -13,6 +13,9 @@ pub struct Config {
     pub price: Coin,
     /// The code ID of the payment contract to be instantatiated
     pub payment_code_id: u64,
+    /// An amount the gateway sends to the payment contract during instantiation.
+    /// Use 0unois to diable.
+    pub payment_initial_funds: Coin,
     /// Address of the Nois sink
     pub sink: Addr,
 }

--- a/contracts/nois-gateway/src/state.rs
+++ b/contracts/nois-gateway/src/state.rs
@@ -83,5 +83,13 @@ pub fn increment_processed_drand_jobs(storage: &mut dyn Storage, round: u64) -> 
     Ok(())
 }
 
-/// A map from channel ID to address of the payment contract
-pub const PAYMENT_ADDRESSES: Map<&str, Addr> = Map::new("pa");
+#[cw_serde]
+pub struct Customer {
+    /// The payment contract address
+    pub payment: Addr,
+    /// Number of beacons requested in total
+    pub requested_beacons: u64,
+}
+
+/// A map from channel ID to customer information
+pub const CUSTOMERS: Map<&str, Customer> = Map::new("customers");

--- a/contracts/nois-gateway/src/state.rs
+++ b/contracts/nois-gateway/src/state.rs
@@ -80,3 +80,6 @@ pub fn increment_processed_drand_jobs(storage: &mut dyn Storage, round: u64) -> 
     PROCESSED_DRAND_JOBS_COUNT.save(storage, round, &(current + 1))?;
     Ok(())
 }
+
+/// A map from channel ID to address of the payment contract
+pub const PAYMENT_ADDRESSES: Map<&str, Addr> = Map::new("pa");

--- a/contracts/nois-gateway/src/state.rs
+++ b/contracts/nois-gateway/src/state.rs
@@ -11,6 +11,8 @@ pub struct Config {
     pub manager: Addr,
     /// The price to pay in order to register the randomness job
     pub price: Coin,
+    /// The code ID of the payment contract to be instantatiated
+    pub payment_code_id: u64,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");

--- a/contracts/nois-gateway/src/state.rs
+++ b/contracts/nois-gateway/src/state.rs
@@ -14,8 +14,9 @@ pub struct Config {
     /// The code ID of the payment contract to be instantatiated
     pub payment_code_id: u64,
     /// An amount the gateway sends to the payment contract during instantiation.
-    /// Use 0unois to diable.
-    pub payment_initial_funds: Coin,
+    /// Used for testing only to avoid draining the gateway's balance by opening channels.
+    /// Use None or 0unois to disable.
+    pub payment_initial_funds: Option<Coin>,
     /// Address of the Nois sink
     pub sink: Addr,
 }

--- a/contracts/nois-gateway/src/state.rs
+++ b/contracts/nois-gateway/src/state.rs
@@ -15,8 +15,6 @@ pub struct Config {
     pub payment_code_id: u64,
     /// Address of the Nois sink
     pub sink: Addr,
-    /// Address of the Nois community pool
-    pub community_pool: Addr,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");

--- a/contracts/nois-gateway/src/state.rs
+++ b/contracts/nois-gateway/src/state.rs
@@ -13,6 +13,10 @@ pub struct Config {
     pub price: Coin,
     /// The code ID of the payment contract to be instantatiated
     pub payment_code_id: u64,
+    /// Address of the Nois sink
+    pub sink: Addr,
+    /// Address of the Nois community pool
+    pub community_pool: Addr,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");

--- a/contracts/nois-payment/Cargo.toml
+++ b/contracts/nois-payment/Cargo.toml
@@ -24,3 +24,6 @@ anything = { path = "../../packages/anything" }
 nois.workspace = true
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
+
+[dev-dependencies]
+hex = { version = "0.4" }

--- a/contracts/nois-payment/Cargo.toml
+++ b/contracts/nois-payment/Cargo.toml
@@ -17,9 +17,10 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { version = "1.2.3" }
+cosmwasm-std = { version = "1.2.3", features = ["stargate"] }
 cosmwasm-schema = { version = "1.2.3" }
 cw-storage-plus = { version = "1.0.0" }
+anything = { path = "../../packages/anything" }
 nois.workspace = true
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }

--- a/contracts/nois-payment/src/contract.rs
+++ b/contracts/nois-payment/src/contract.rs
@@ -16,11 +16,11 @@ pub fn instantiate(
 ) -> Result<Response, ContractError> {
     let nois_sink_addr = deps
         .api
-        .addr_validate(&msg.nois_sink)
+        .addr_validate(&msg.sink)
         .map_err(|_| ContractError::InvalidAddress)?;
     let nois_com_pool_addr = deps
         .api
-        .addr_validate(&msg.nois_com_pool_addr)
+        .addr_validate(&msg.community_pool)
         .map_err(|_| ContractError::InvalidAddress)?;
     CONFIG.save(
         deps.storage,
@@ -32,8 +32,8 @@ pub fn instantiate(
     )?;
     Ok(Response::new()
         .add_attribute("action", "instantiate")
-        .add_attribute("nois_sink", msg.nois_sink)
-        .add_attribute("nois_community_pool", msg.nois_com_pool_addr)
+        .add_attribute("nois_sink", msg.sink)
+        .add_attribute("nois_community_pool", msg.community_pool)
         .add_attribute("nois_gateway", info.sender))
 }
 
@@ -164,8 +164,8 @@ mod tests {
     fn instantiate_works() {
         let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
-            nois_sink: NOIS_SINK.to_string(),
-            nois_com_pool_addr: NOIS_COMMUNITY_POOL.to_string(),
+            sink: NOIS_SINK.to_string(),
+            community_pool: NOIS_COMMUNITY_POOL.to_string(),
         };
         let info = mock_info(NOIS_GATEWAY, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -186,8 +186,8 @@ mod tests {
     fn cannot_send_funds() {
         let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
-            nois_sink: NOIS_SINK.to_string(),
-            nois_com_pool_addr: NOIS_COMMUNITY_POOL.to_string(),
+            sink: NOIS_SINK.to_string(),
+            community_pool: NOIS_COMMUNITY_POOL.to_string(),
         };
         let info = mock_info(NOIS_GATEWAY, &[]);
         let _result = instantiate(deps.as_mut(), mock_env(), info, msg);
@@ -219,8 +219,8 @@ mod tests {
     fn only_gateway_can_pay() {
         let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
-            nois_sink: NOIS_SINK.to_string(),
-            nois_com_pool_addr: NOIS_COMMUNITY_POOL.to_string(),
+            sink: NOIS_SINK.to_string(),
+            community_pool: NOIS_COMMUNITY_POOL.to_string(),
         };
         let info = mock_info(NOIS_GATEWAY, &[]);
         let _result = instantiate(deps.as_mut(), mock_env(), info, msg);
@@ -252,8 +252,8 @@ mod tests {
     fn pay_fund_send_works() {
         let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
-            nois_sink: NOIS_SINK.to_string(),
-            nois_com_pool_addr: NOIS_COMMUNITY_POOL.to_string(),
+            sink: NOIS_SINK.to_string(),
+            community_pool: NOIS_COMMUNITY_POOL.to_string(),
         };
         let info = mock_info(NOIS_GATEWAY, &[]);
         let _result = instantiate(deps.as_mut(), mock_env(), info, msg);

--- a/contracts/nois-payment/src/contract.rs
+++ b/contracts/nois-payment/src/contract.rs
@@ -123,7 +123,7 @@ fn execute_pay(
             .append_bytes(1, &community_pool.denom)
             .append_bytes(2, community_pool.amount.to_string());
         let msg_fund_community_pool = Anything::new()
-            .append_anything(1, &coin)
+            .append_message(1, &coin)
             .append_bytes(2, env.contract.address.as_bytes())
             .into_vec();
         out_msgs.push(CosmosMsg::Stargate {

--- a/contracts/nois-payment/src/contract.rs
+++ b/contracts/nois-payment/src/contract.rs
@@ -19,14 +19,9 @@ pub fn instantiate(
         .api
         .addr_validate(&msg.sink)
         .map_err(|_| ContractError::InvalidAddress)?;
-    let nois_com_pool_addr = deps
-        .api
-        .addr_validate(&msg.community_pool)
-        .map_err(|_| ContractError::InvalidAddress)?;
     CONFIG.save(
         deps.storage,
         &Config {
-            community_pool: nois_com_pool_addr,
             sink: nois_sink_addr,
             gateway: info.sender.clone(),
         },
@@ -34,7 +29,6 @@ pub fn instantiate(
     Ok(Response::new()
         .add_attribute("action", "instantiate")
         .add_attribute("nois_sink", msg.sink)
-        .add_attribute("nois_community_pool", msg.community_pool)
         .add_attribute("nois_gateway", info.sender))
 }
 
@@ -153,7 +147,6 @@ mod tests {
     };
 
     const NOIS_SINK: &str = "sink";
-    const NOIS_COMMUNITY_POOL: &str = "community_pool";
     const NOIS_GATEWAY: &str = "nois-gateway";
 
     /// Gets the value of the first attribute with the given key
@@ -172,7 +165,6 @@ mod tests {
         let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
             sink: NOIS_SINK.to_string(),
-            community_pool: NOIS_COMMUNITY_POOL.to_string(),
         };
         let info = mock_info(NOIS_GATEWAY, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -182,7 +174,6 @@ mod tests {
         assert_eq!(
             config,
             ConfigResponse {
-                community_pool: Addr::unchecked(NOIS_COMMUNITY_POOL),
                 sink: Addr::unchecked(NOIS_SINK),
                 gateway: Addr::unchecked(NOIS_GATEWAY),
             }
@@ -194,7 +185,6 @@ mod tests {
         let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
             sink: NOIS_SINK.to_string(),
-            community_pool: NOIS_COMMUNITY_POOL.to_string(),
         };
         let info = mock_info(NOIS_GATEWAY, &[]);
         let _result = instantiate(deps.as_mut(), mock_env(), info, msg);
@@ -227,7 +217,6 @@ mod tests {
         let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
             sink: NOIS_SINK.to_string(),
-            community_pool: NOIS_COMMUNITY_POOL.to_string(),
         };
         let info = mock_info(NOIS_GATEWAY, &[]);
         let _result = instantiate(deps.as_mut(), mock_env(), info, msg);
@@ -260,7 +249,6 @@ mod tests {
         let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
             sink: NOIS_SINK.to_string(),
-            community_pool: NOIS_COMMUNITY_POOL.to_string(),
         };
         let info = mock_info(NOIS_GATEWAY, &[]);
         let _result = instantiate(deps.as_mut(), mock_env(), info, msg);

--- a/contracts/nois-payment/src/contract.rs
+++ b/contracts/nois-payment/src/contract.rs
@@ -7,7 +7,7 @@ use crate::error::ContractError;
 use crate::msg::{ConfigResponse, ExecuteMsg, InstantiateMsg, NoisSinkExecuteMsg, QueryMsg};
 use crate::state::{Config, CONFIG};
 
-#[entry_point]
+#[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
     deps: DepsMut,
     _env: Env,
@@ -37,7 +37,7 @@ pub fn instantiate(
         .add_attribute("nois_gateway", info.sender))
 }
 
-#[entry_point]
+#[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut,
     env: Env,
@@ -53,7 +53,7 @@ pub fn execute(
     }
 }
 
-#[entry_point]
+#[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
     let response = match msg {
         QueryMsg::Config {} => to_binary(&query_config(deps)?)?,

--- a/contracts/nois-payment/src/msg.rs
+++ b/contracts/nois-payment/src/msg.rs
@@ -7,8 +7,6 @@ use crate::state::Config;
 pub struct InstantiateMsg {
     /// Address of the Nois sink
     pub sink: String,
-    /// Address of the Nois community pool
-    pub community_pool: String,
 }
 
 #[cw_serde]

--- a/contracts/nois-payment/src/msg.rs
+++ b/contracts/nois-payment/src/msg.rs
@@ -5,8 +5,10 @@ use crate::state::Config;
 
 #[cw_serde]
 pub struct InstantiateMsg {
-    pub nois_sink: String,
-    pub nois_com_pool_addr: String,
+    /// Address of the Nois sink
+    pub sink: String,
+    /// Address of the Nois community pool
+    pub community_pool: String,
 }
 
 #[cw_serde]

--- a/contracts/nois-payment/src/state.rs
+++ b/contracts/nois-payment/src/state.rs
@@ -6,8 +6,6 @@ use cw_storage_plus::Item;
 pub struct Config {
     /// The address of the sink contract to burn the used tokens.
     pub sink: Addr,
-    /// The address of the community pool.
-    pub community_pool: Addr,
     /// The address of nois-gateway
     pub gateway: Addr,
 }

--- a/contracts/nois-proxy/src/error.rs
+++ b/contracts/nois-proxy/src/error.rs
@@ -15,6 +15,12 @@ pub enum ContractError {
     #[error("Insufficient payment.")]
     InsufficientPayment,
 
+    //
+    // IBC
+    //
+    #[error("The nois-proxy contract must be on chain A of the connection. Try swapping A and B in the channel creation.")]
+    MustBeChainA,
+
     #[error("Unsupported packet type.")]
     UnsupportedPacketType,
 

--- a/contracts/nois-proxy/src/error.rs
+++ b/contracts/nois-proxy/src/error.rs
@@ -15,6 +15,9 @@ pub enum ContractError {
     #[error("Insufficient payment.")]
     InsufficientPayment,
 
+    #[error("Unsupported packet type.")]
+    UnsupportedPacketType,
+
     #[error("Channel is not stored. Channel not yet established or closed.")]
     UnsetChannel,
 

--- a/contracts/nois-proxy/src/state.rs
+++ b/contracts/nois-proxy/src/state.rs
@@ -12,6 +12,8 @@ pub struct Config {
     pub test_mode: bool,
     /// The amount of gas that the callback to the dapp can consume
     pub callback_gas_limit: u64,
+    /// Address of the payment contract (on the other chain)
+    pub payment: Option<String>,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");

--- a/packages/anything/Cargo.toml
+++ b/packages/anything/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "anything"
+version = "0.11.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[dev-dependencies]

--- a/packages/anything/src/lib.rs
+++ b/packages/anything/src/lib.rs
@@ -1,0 +1,150 @@
+//! A minimal (like seriously), zero dependency protobuf encoder.
+//!
+//! Supported:
+//! - Varint (u64)
+//! - Repeated: Just append a field multiple times
+//! - Nested: Just append an `Anything` instance
+//!
+//! Non supported:
+//!
+//! - Fixed length types
+//! - Field sorting
+
+#[derive(Default)]
+pub struct Anything {
+    output: Vec<u8>,
+}
+
+/// The protobuf wire types
+///
+/// <https://protobuf.dev/programming-guides/encoding/#structure>
+#[repr(u32)]
+enum WireType {
+    /// Variable length field (int32, int64, uint32, uint64, sint32, sint64, bool, enum)
+    Varint = 0,
+    // Fixed length types unsupported
+    // I64 = 1,
+    /// Lengths prefixed field (string, bytes, embedded messages, packed repeated fields)
+    Len = 2,
+    // group start/end (deprecated, unsupported)
+    // SGROUP = 3,
+    // EGROUP = 4,
+    // Fixed length types unsupported
+    // I32 = 5,
+}
+
+fn varint_encode(mut n: u64, dest: &mut Vec<u8>) {
+    let mut buf = [0u8; 10];
+    let mut len = 0;
+    loop {
+        // Read least significant 7 bits
+        let mut b = (n & 0b0111_1111) as u8;
+        n >>= 7;
+        // Set top bit when not yet done
+        if n != 0 {
+            b |= 0b1000_0000;
+        }
+        buf[len] = b;
+        len += 1;
+        if n == 0 {
+            break;
+        }
+    }
+    dest.extend_from_slice(&buf[0..len]);
+}
+
+impl Anything {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn append_bytes(mut self, field_number: u32, data: impl AsRef<[u8]>) -> Self {
+        let data = data.as_ref();
+        if data.is_empty() {
+            return self;
+        }
+        // tag
+        self.append_tag(field_number, WireType::Len);
+        // length
+        varint_encode(data.len() as u64, &mut self.output);
+        // value
+        self.output.extend_from_slice(data);
+        self
+    }
+
+    pub fn append_u64(mut self, field_number: u32, value: u64) -> Self {
+        if value == 0 {
+            return self;
+        }
+        self.append_tag(field_number, WireType::Varint);
+        varint_encode(value, &mut self.output);
+        self
+    }
+
+    pub fn append_anything(self, field_number: u32, value: &Anything) -> Self {
+        self.append_bytes(field_number, value.as_bytes())
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.output
+    }
+
+    /// Takes the instance and returns the protobuf bytes
+    pub fn into_vec(self) -> Vec<u8> {
+        self.output
+    }
+
+    fn append_tag(&mut self, field_number: u32, field_type: WireType) {
+        let tag: u32 = (field_number << 3) | field_type as u32;
+        varint_encode(tag as u64, &mut self.output);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_returns_empty_data() {
+        let data = Anything::new();
+        assert_eq!(data.into_vec(), &[]);
+    }
+
+    #[test]
+    fn append_u64() {
+        let data = Anything::new().append_u64(1, 150);
+        assert_eq!(data.into_vec(), [0b00001000, 0b10010110, 0b00000001]);
+
+        // Zero/Default field not written
+        let data = Anything::new().append_u64(1, 0);
+        assert_eq!(data.into_vec(), &[]);
+    }
+
+    #[test]
+    fn append_bytes() {
+        // &str
+        let data = Anything::new().append_bytes(2, "testing");
+        assert_eq!(
+            data.into_vec(),
+            [0x12, 0x07, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67]
+        );
+
+        // String
+        let data = Anything::new().append_bytes(2, String::from("testing"));
+        assert_eq!(
+            data.into_vec(),
+            [0x12, 0x07, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67]
+        );
+
+        // &[u8]
+        let data = Anything::new().append_bytes(2, b"testing");
+        assert_eq!(
+            data.into_vec(),
+            [0x12, 0x07, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67]
+        );
+
+        // Empty field not written
+        let data = Anything::new().append_bytes(2, b"");
+        assert_eq!(data.into_vec(), []);
+    }
+}

--- a/packages/anything/tests.proto
+++ b/packages/anything/tests.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+message Lights {
+  bool on = 3;
+}
+
+message Room {
+  uint32 number = 1;
+  Lights lights = 2;
+  uint64 size = 3;
+}

--- a/packages/multitest/Cargo.toml
+++ b/packages/multitest/Cargo.toml
@@ -20,6 +20,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 nois-drand = { path = "../../contracts/nois-drand"}
 nois-gateway = { path = "../../contracts/nois-gateway"}
 nois-icecube = { path = "../../contracts/nois-icecube"}
+nois-payment = { path = "../../contracts/nois-payment" }
 nois-proxy = { path = "../../contracts/nois-proxy" }
 
 cosmwasm-std = { version = "1.2.3", features = ["iterator", "ibc3"] }

--- a/packages/multitest/README.md
+++ b/packages/multitest/README.md
@@ -2,15 +2,15 @@
 
 Steps:
 
-- Instantiate and check nois-delegator contract
-- Instantiate and check nois-oracle contract
-- Set nois-oracle address in nois-delegator
+- Instantiate and check nois-icecube contract
+- Instantiate and check nois-drand contract
+- Set nois-drand address in nois-icecube
 - Instantiate nois-proxy
-- Register a bot in nois-oracle
-- Check that a non admin cannot whitelist a bot
-- Whitelist the bot
-- Add randomness round in nois-oracle
-- Check that the incentive has been paid from the delegator contract to the
+- Register a bot in nois-drand
+- Check that a non manager cannot allowlist a bot
+- Allowlist the bot
+- Add randomness round in nois-drand
+- Check that the incentive has been paid from the icecube contract to the
   drand-operator by checking the respective Bank balances
-- As admin, make the nois-delegator delegate to a validator and check that the
+- As manager, make the nois-icecube delegate to a validator and check that the
   delegations are queriable

--- a/packages/multitest/src/lib.rs
+++ b/packages/multitest/src/lib.rs
@@ -43,6 +43,6 @@ pub fn mint_native(
     .unwrap();
 }
 
-pub fn payment_initial() -> Coin {
-    coin(2_000000, "unois")
+pub fn payment_initial() -> Option<Coin> {
+    Some(coin(2_000000, "unois"))
 }

--- a/packages/multitest/src/lib.rs
+++ b/packages/multitest/src/lib.rs
@@ -1,7 +1,7 @@
 // Testing utils. See tests folder for actual tests.
 
 use cosmwasm_std::{
-    from_binary, to_binary, Addr, Attribute, BalanceResponse, BankQuery, Coin, Querier,
+    coin, from_binary, to_binary, Addr, Attribute, BalanceResponse, BankQuery, Coin, Querier,
     QueryRequest,
 };
 use cw_multi_test::App;
@@ -41,4 +41,8 @@ pub fn mint_native(
         },
     ))
     .unwrap();
+}
+
+pub fn payment_initial() -> Coin {
+    coin(2_000000, "unois")
 }

--- a/packages/multitest/tests/drand-gateway.rs
+++ b/packages/multitest/tests/drand-gateway.rs
@@ -5,6 +5,8 @@ use cw_multi_test::{AppBuilder, ContractWrapper, Executor, StakingInfo};
 use nois_multitest::{first_attr, mint_native, query_balance_native};
 
 const PAYMENT: u64 = 33;
+const SINK: &str = "sink";
+const COMMUNOTY_POOL: &str = "community_pool";
 
 #[test]
 fn integration_test() {
@@ -93,6 +95,8 @@ fn integration_test() {
                 manager: "manager".to_string(),
                 price: Coin::new(1, "unois"),
                 payment_code_id: PAYMENT,
+                sink: SINK.to_string(),
+                community_pool: COMMUNOTY_POOL.to_string(),
             },
             &[],
             "Nois-Gateway",
@@ -112,6 +116,8 @@ fn integration_test() {
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            sink: Addr::unchecked(SINK),
+            community_pool: Addr::unchecked(COMMUNOTY_POOL),
         }
     );
 
@@ -168,6 +174,8 @@ fn integration_test() {
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            sink: Addr::unchecked(SINK),
+            community_pool: Addr::unchecked(COMMUNOTY_POOL),
         }
     );
 

--- a/packages/multitest/tests/drand-gateway.rs
+++ b/packages/multitest/tests/drand-gateway.rs
@@ -5,7 +5,6 @@ use cw_multi_test::{AppBuilder, ContractWrapper, Executor, StakingInfo};
 use nois_multitest::{first_attr, mint_native, query_balance_native};
 
 const SINK: &str = "sink";
-const COMMUNOTY_POOL: &str = "community_pool";
 
 #[test]
 fn integration_test() {
@@ -103,7 +102,6 @@ fn integration_test() {
                 price: Coin::new(1, "unois"),
                 payment_code_id: code_id_nois_payment,
                 sink: SINK.to_string(),
-                community_pool: COMMUNOTY_POOL.to_string(),
             },
             &[],
             "Nois-Gateway",
@@ -124,7 +122,6 @@ fn integration_test() {
             price: Coin::new(1, "unois"),
             payment_code_id: code_id_nois_payment,
             sink: Addr::unchecked(SINK),
-            community_pool: Addr::unchecked(COMMUNOTY_POOL),
         }
     );
 
@@ -182,7 +179,6 @@ fn integration_test() {
             price: Coin::new(1, "unois"),
             payment_code_id: code_id_nois_payment,
             sink: Addr::unchecked(SINK),
-            community_pool: Addr::unchecked(COMMUNOTY_POOL),
         }
     );
 

--- a/packages/multitest/tests/drand-gateway.rs
+++ b/packages/multitest/tests/drand-gateway.rs
@@ -4,7 +4,6 @@ use cosmwasm_std::{testing::mock_env, Addr, Coin, Decimal, HexBinary, Uint128, V
 use cw_multi_test::{AppBuilder, ContractWrapper, Executor, StakingInfo};
 use nois_multitest::{first_attr, mint_native, query_balance_native};
 
-const PAYMENT: u64 = 33;
 const SINK: &str = "sink";
 const COMMUNOTY_POOL: &str = "community_pool";
 
@@ -78,6 +77,14 @@ fn integration_test() {
         }
     );
 
+    // Storing nois-payment code
+    let code_nois_payment = ContractWrapper::new(
+        nois_payment::contract::execute,
+        nois_payment::contract::instantiate,
+        nois_payment::contract::query,
+    );
+    let code_id_nois_payment = app.store_code(Box::new(code_nois_payment));
+
     // Storing nois-gateway code
     let code_nois_gateway = ContractWrapper::new(
         nois_gateway::contract::execute,
@@ -94,7 +101,7 @@ fn integration_test() {
             &nois_gateway::msg::InstantiateMsg {
                 manager: "manager".to_string(),
                 price: Coin::new(1, "unois"),
-                payment_code_id: PAYMENT,
+                payment_code_id: code_id_nois_payment,
                 sink: SINK.to_string(),
                 community_pool: COMMUNOTY_POOL.to_string(),
             },
@@ -115,7 +122,7 @@ fn integration_test() {
             drand: None,
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
-            payment_code_id: PAYMENT,
+            payment_code_id: code_id_nois_payment,
             sink: Addr::unchecked(SINK),
             community_pool: Addr::unchecked(COMMUNOTY_POOL),
         }
@@ -173,7 +180,7 @@ fn integration_test() {
             drand: Some(addr_nois_drand.clone()),
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
-            payment_code_id: PAYMENT,
+            payment_code_id: code_id_nois_payment,
             sink: Addr::unchecked(SINK),
             community_pool: Addr::unchecked(COMMUNOTY_POOL),
         }
@@ -482,13 +489,4 @@ fn integration_test() {
     // Check balance nois-gateway
     let balance = query_balance_native(&app, &addr_nois_gateway, "unois").amount;
     assert_eq!(balance, Uint128::new(0));
-
-    // Check balance nois-drand-bot-operator
-    // let balance = query_balance_native(&app, &Addr::unchecked("drand_bot"), "unois").amount;
-    // assert_eq!(
-    //     balance,
-    //     Uint128::new(100_000) //incentive
-    // );
-
-    //TODO simulte advance many blocks to accumulate some staking rewards
 }

--- a/packages/multitest/tests/drand-gateway.rs
+++ b/packages/multitest/tests/drand-gateway.rs
@@ -2,7 +2,7 @@
 
 use cosmwasm_std::{testing::mock_env, Addr, Coin, Decimal, HexBinary, Uint128, Validator};
 use cw_multi_test::{AppBuilder, ContractWrapper, Executor, StakingInfo};
-use nois_multitest::{first_attr, mint_native, query_balance_native};
+use nois_multitest::{first_attr, mint_native, payment_initial, query_balance_native};
 
 const SINK: &str = "sink";
 
@@ -101,6 +101,7 @@ fn integration_test() {
                 manager: "manager".to_string(),
                 price: Coin::new(1, "unois"),
                 payment_code_id: code_id_nois_payment,
+                payment_initial_funds: payment_initial(),
                 sink: SINK.to_string(),
             },
             &[],
@@ -121,6 +122,7 @@ fn integration_test() {
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
             payment_code_id: code_id_nois_payment,
+            payment_initial_funds: payment_initial(),
             sink: Addr::unchecked(SINK),
         }
     );
@@ -178,6 +180,7 @@ fn integration_test() {
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
             payment_code_id: code_id_nois_payment,
+            payment_initial_funds: payment_initial(),
             sink: Addr::unchecked(SINK),
         }
     );

--- a/packages/multitest/tests/drand-gateway.rs
+++ b/packages/multitest/tests/drand-gateway.rs
@@ -4,6 +4,8 @@ use cosmwasm_std::{testing::mock_env, Addr, Coin, Decimal, HexBinary, Uint128, V
 use cw_multi_test::{AppBuilder, ContractWrapper, Executor, StakingInfo};
 use nois_multitest::{first_attr, mint_native, query_balance_native};
 
+const PAYMENT: u64 = 33;
+
 #[test]
 fn integration_test() {
     // Insantiate a chain mock environment
@@ -90,6 +92,7 @@ fn integration_test() {
             &nois_gateway::msg::InstantiateMsg {
                 manager: "manager".to_string(),
                 price: Coin::new(1, "unois"),
+                payment_code_id: PAYMENT,
             },
             &[],
             "Nois-Gateway",
@@ -108,6 +111,7 @@ fn integration_test() {
             drand: None,
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
+            payment_code_id: PAYMENT,
         }
     );
 
@@ -148,6 +152,7 @@ fn integration_test() {
             manager: None,
             price: None,
             drand_addr: Some(addr_nois_drand.to_string()),
+            payment_code_id: None,
         },
         &[],
     )
@@ -162,6 +167,7 @@ fn integration_test() {
             drand: Some(addr_nois_drand.clone()),
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
+            payment_code_id: PAYMENT,
         }
     );
 

--- a/packages/multitest/tests/drand-gateway.rs
+++ b/packages/multitest/tests/drand-gateway.rs
@@ -217,6 +217,7 @@ fn integration_test() {
                 withdrawal_address: Addr::unchecked("dao_dao_dao_dao_dao"),
                 test_mode: false,
                 callback_gas_limit: 500_000,
+                payment: None,
             },
         }
     );

--- a/packages/multitest/tests/drand-gateway.rs
+++ b/packages/multitest/tests/drand-gateway.rs
@@ -164,7 +164,6 @@ fn integration_test() {
             manager: None,
             price: None,
             drand_addr: Some(addr_nois_drand.to_string()),
-            payment_code_id: None,
             payment_initial_funds: None,
         },
         &[],

--- a/packages/multitest/tests/drand-gateway.rs
+++ b/packages/multitest/tests/drand-gateway.rs
@@ -165,6 +165,7 @@ fn integration_test() {
             price: None,
             drand_addr: Some(addr_nois_drand.to_string()),
             payment_code_id: None,
+            payment_initial_funds: None,
         },
         &[],
     )

--- a/packages/multitest/tests/multitest.rs
+++ b/packages/multitest/tests/multitest.rs
@@ -152,6 +152,7 @@ fn integration_test() {
                 withdrawal_address: Addr::unchecked("dao_dao_dao_dao_dao"),
                 test_mode: false,
                 callback_gas_limit: 500_000,
+                payment: None,
             },
         }
     );

--- a/packages/multitest/tests/multitest.rs
+++ b/packages/multitest/tests/multitest.rs
@@ -87,6 +87,7 @@ fn integration_test() {
         price: None,
         drand_addr: Some(DRAND.to_string()),
         payment_code_id: None,
+        payment_initial_funds: None,
     };
     let _resp = app
         .execute_contract(

--- a/packages/multitest/tests/multitest.rs
+++ b/packages/multitest/tests/multitest.rs
@@ -3,6 +3,8 @@ use cw_multi_test::{AppBuilder, ContractWrapper, Executor, StakingInfo};
 use nois_multitest::mint_native;
 
 const PAYMENT: u64 = 17;
+const SINK: &str = "sink";
+const COMMUNOTY_POOL: &str = "community_pool";
 
 #[test]
 fn integration_test() {
@@ -52,6 +54,8 @@ fn integration_test() {
                 manager: "manager".to_string(),
                 price: Coin::new(1, "unois"),
                 payment_code_id: PAYMENT,
+                sink: SINK.to_string(),
+                community_pool: COMMUNOTY_POOL.to_string(),
             },
             &[],
             "Nois-Gateway",
@@ -70,7 +74,9 @@ fn integration_test() {
             drand: None,
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
-            payment_code_id: PAYMENT
+            payment_code_id: PAYMENT,
+            sink: Addr::unchecked(SINK),
+            community_pool: Addr::unchecked(COMMUNOTY_POOL),
         }
     );
 
@@ -104,6 +110,8 @@ fn integration_test() {
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            sink: Addr::unchecked(SINK),
+            community_pool: Addr::unchecked(COMMUNOTY_POOL),
         }
     );
 

--- a/packages/multitest/tests/multitest.rs
+++ b/packages/multitest/tests/multitest.rs
@@ -86,7 +86,6 @@ fn integration_test() {
         manager: None,
         price: None,
         drand_addr: Some(DRAND.to_string()),
-        payment_code_id: None,
         payment_initial_funds: None,
     };
     let _resp = app

--- a/packages/multitest/tests/multitest.rs
+++ b/packages/multitest/tests/multitest.rs
@@ -2,6 +2,8 @@ use cosmwasm_std::{testing::mock_env, Addr, Coin, Decimal, HexBinary, Validator}
 use cw_multi_test::{AppBuilder, ContractWrapper, Executor, StakingInfo};
 use nois_multitest::mint_native;
 
+const PAYMENT: u64 = 17;
+
 #[test]
 fn integration_test() {
     // Insantiate a chain mock environment
@@ -49,6 +51,7 @@ fn integration_test() {
             &nois_gateway::msg::InstantiateMsg {
                 manager: "manager".to_string(),
                 price: Coin::new(1, "unois"),
+                payment_code_id: PAYMENT,
             },
             &[],
             "Nois-Gateway",
@@ -67,6 +70,7 @@ fn integration_test() {
             drand: None,
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
+            payment_code_id: PAYMENT
         }
     );
 
@@ -77,6 +81,7 @@ fn integration_test() {
         manager: None,
         price: None,
         drand_addr: Some(DRAND.to_string()),
+        payment_code_id: None,
     };
     let _resp = app
         .execute_contract(
@@ -98,6 +103,7 @@ fn integration_test() {
             drand: Some(Addr::unchecked(DRAND)),
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
+            payment_code_id: PAYMENT,
         }
     );
 

--- a/packages/multitest/tests/multitest.rs
+++ b/packages/multitest/tests/multitest.rs
@@ -4,7 +4,6 @@ use nois_multitest::mint_native;
 
 const PAYMENT: u64 = 17;
 const SINK: &str = "sink";
-const COMMUNOTY_POOL: &str = "community_pool";
 
 #[test]
 fn integration_test() {
@@ -55,7 +54,6 @@ fn integration_test() {
                 price: Coin::new(1, "unois"),
                 payment_code_id: PAYMENT,
                 sink: SINK.to_string(),
-                community_pool: COMMUNOTY_POOL.to_string(),
             },
             &[],
             "Nois-Gateway",
@@ -76,7 +74,6 @@ fn integration_test() {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: Addr::unchecked(SINK),
-            community_pool: Addr::unchecked(COMMUNOTY_POOL),
         }
     );
 
@@ -111,7 +108,6 @@ fn integration_test() {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: Addr::unchecked(SINK),
-            community_pool: Addr::unchecked(COMMUNOTY_POOL),
         }
     );
 

--- a/packages/multitest/tests/multitest.rs
+++ b/packages/multitest/tests/multitest.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{testing::mock_env, Addr, Coin, Decimal, HexBinary, Validator};
 use cw_multi_test::{AppBuilder, ContractWrapper, Executor, StakingInfo};
-use nois_multitest::mint_native;
+use nois_multitest::{mint_native, payment_initial};
 
 const PAYMENT: u64 = 17;
 const SINK: &str = "sink";
@@ -53,6 +53,7 @@ fn integration_test() {
                 manager: "manager".to_string(),
                 price: Coin::new(1, "unois"),
                 payment_code_id: PAYMENT,
+                payment_initial_funds: payment_initial(),
                 sink: SINK.to_string(),
             },
             &[],
@@ -73,6 +74,7 @@ fn integration_test() {
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            payment_initial_funds: payment_initial(),
             sink: Addr::unchecked(SINK),
         }
     );
@@ -107,6 +109,7 @@ fn integration_test() {
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
+            payment_initial_funds: payment_initial(),
             sink: Addr::unchecked(SINK),
         }
     );

--- a/packages/nois-protocol/examples/schema.rs
+++ b/packages/nois-protocol/examples/schema.rs
@@ -3,7 +3,7 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
-use nois_protocol::{DeliverBeaconPacket, RequestBeaconPacket, StdAck};
+use nois_protocol::{OutPacket, RequestBeaconPacket, StdAck};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -12,6 +12,6 @@ fn main() {
     remove_schemas(&out_dir).unwrap();
 
     export_schema(&schema_for!(RequestBeaconPacket), &out_dir);
-    export_schema(&schema_for!(DeliverBeaconPacket), &out_dir);
+    export_schema(&schema_for!(OutPacket), &out_dir);
     export_schema(&schema_for!(StdAck), &out_dir);
 }

--- a/packages/nois-protocol/src/ibc_msg.rs
+++ b/packages/nois-protocol/src/ibc_msg.rs
@@ -28,22 +28,35 @@ pub enum RequestBeaconPacketAck {
 
 /// This is the message we send over the IBC channel from nois-gateway to nois-proxy.
 #[cw_serde]
-pub struct DeliverBeaconPacket {
-    /// A RNG specific randomness source identifier, e.g. `drand:<network id>:<round>`
-    pub source_id: String,
-    pub randomness: HexBinary,
-    /// The origin data set by the proxy in a proxy specific format.
-    pub origin: Binary,
+#[non_exhaustive]
+pub enum OutPacket {
+    DeliverBeacon {
+        /// A RNG specific randomness source identifier, e.g. `drand:<network id>:<round>`
+        source_id: String,
+        randomness: HexBinary,
+        /// The origin data set by the proxy in a proxy specific format.
+        origin: Binary,
+    },
+    Welcome {
+        /// Payment address on the Nois blockchain
+        payment: String,
+    },
 }
 
-/// The ack the proxy must send when receiving a [`DeliverBeaconPacket`].
+/// The ack the proxy must send when receiving a `OutPacket::DeliverBeacon`.
 ///
-/// This is a lighweight structre as the gateway does not do anything other than
+/// This is a lighweight structure as the gateway does not do anything other than
 /// simple logging of the beacon delivery ack.
 #[non_exhaustive]
 #[cw_serde]
 #[derive(Default)]
 pub struct DeliverBeaconPacketAck {}
+
+/// The ack the proxy must send when receiving a `OutPacket::Welcome`.
+#[non_exhaustive]
+#[cw_serde]
+#[derive(Default)]
+pub struct WelcomePacketAck {}
 
 /// This is a generic ICS acknowledgement format.
 /// Proto defined here: https://github.com/cosmos/cosmos-sdk/blob/v0.42.0/proto/ibc/core/channel/v1/channel.proto#L141-L147

--- a/packages/nois-protocol/src/lib.rs
+++ b/packages/nois-protocol/src/lib.rs
@@ -5,11 +5,11 @@ use cosmwasm_std::IbcOrder;
 
 pub use checks::{check_order, check_version, ChannelError};
 pub use ibc_msg::{
-    DeliverBeaconPacket, DeliverBeaconPacketAck, RequestBeaconPacket, RequestBeaconPacketAck,
-    StdAck,
+    DeliverBeaconPacketAck, OutPacket, RequestBeaconPacket, RequestBeaconPacketAck, StdAck,
+    WelcomePacketAck,
 };
 
-pub const IBC_APP_VERSION: &str = "nois-v5";
+pub const IBC_APP_VERSION: &str = "nois-v6";
 pub const APP_ORDER: IbcOrder = IbcOrder::Unordered;
 // we use this for tests to ensure it is rejected
 pub const BAD_APP_ORDER: IbcOrder = IbcOrder::Ordered;
@@ -21,3 +21,4 @@ pub const BAD_APP_ORDER: IbcOrder = IbcOrder::Ordered;
 // timeouts due to relayer downtime, we set the lifetime to 100 days.
 pub const REQUEST_BEACON_PACKET_LIFETIME: u64 = 100 * 24 * 3600; // seconds
 pub const DELIVER_BEACON_PACKET_LIFETIME: u64 = 100 * 24 * 3600; // seconds
+pub const WELCOME_PACKET_LIFETIME: u64 = 100 * 24 * 3600; // seconds

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -16,6 +16,7 @@
         "@cosmjs/cosmwasm-stargate": "^0.30.1",
         "@cosmjs/crypto": "^0.30.1",
         "@cosmjs/encoding": "^0.30.1",
+        "@cosmjs/math": "^0.30.1",
         "@cosmjs/stargate": "^0.30.1",
         "@cosmjs/utils": "^0.30.1",
         "@types/node": "^18.0.6",

--- a/tests/package.json
+++ b/tests/package.json
@@ -26,6 +26,7 @@
     "@cosmjs/cosmwasm-stargate": "^0.30.1",
     "@cosmjs/crypto": "^0.30.1",
     "@cosmjs/encoding": "^0.30.1",
+    "@cosmjs/math": "^0.30.1",
     "@cosmjs/stargate": "^0.30.1",
     "@cosmjs/utils": "^0.30.1",
     "@types/node": "^18.0.6",

--- a/tests/src/contracts.ts
+++ b/tests/src/contracts.ts
@@ -49,8 +49,6 @@ export interface GatewayInstantiateMsg {
   readonly payment_code_id: number;
   /** Address of the Nois sink */
   readonly sink: string;
-  /** Address of the Nois community pool */
-  readonly community_pool: string;
 }
 
 export interface GatewayExecuteMsg {

--- a/tests/src/contracts.ts
+++ b/tests/src/contracts.ts
@@ -50,6 +50,7 @@ export interface GatewayInstantiateMsg {
   readonly manager: string;
   readonly price: Coin;
   readonly payment_code_id: number;
+  readonly payment_initial_funds: Coin;
   /** Address of the Nois sink */
   readonly sink: string;
 }

--- a/tests/src/contracts.ts
+++ b/tests/src/contracts.ts
@@ -69,6 +69,16 @@ export interface GatewayExecuteMsg {
   };
 }
 
+export interface GatewayQueriedCustomer {
+  readonly channel_id: string;
+  readonly payment: string;
+  readonly requested_beacons: number;
+}
+
+export interface GatewayCustomerResponse {
+  readonly customer: null | GatewayQueriedCustomer;
+}
+
 export interface ProxyInstantiateMsg {
   readonly prices: Array<Coin>;
   readonly withdrawal_address: string;

--- a/tests/src/contracts.ts
+++ b/tests/src/contracts.ts
@@ -66,7 +66,7 @@ export interface GatewayExecuteMsg {
     readonly price?: null | Coin;
     readonly drand_addr?: null | string;
     readonly payment_code_id?: null | number;
-    readonly payment_initial_funds?: null | number;
+    readonly payment_initial_funds?: null | Coin;
   };
 }
 

--- a/tests/src/contracts.ts
+++ b/tests/src/contracts.ts
@@ -46,6 +46,7 @@ export interface DrandExecuteMsg {
 export interface GatewayInstantiateMsg {
   readonly manager: string;
   readonly price: Coin;
+  readonly payment_code_id: number;
 }
 
 export interface GatewayExecuteMsg {
@@ -54,7 +55,12 @@ export interface GatewayExecuteMsg {
     readonly randomness: string;
     readonly is_verifying_tx: boolean;
   };
-  readonly set_config?: { drand_addr: string };
+  readonly set_config?: {
+    readonly manager?: null | string;
+    readonly price?: null | Coin;
+    readonly drand_addr?: null | string;
+    readonly payment_code_id?: null | number;
+  };
 }
 
 export interface ProxyInstantiateMsg {

--- a/tests/src/contracts.ts
+++ b/tests/src/contracts.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
 import { readFileSync } from "fs";
 
 import { CosmWasmSigner } from "@confio/relayer";
@@ -43,6 +44,8 @@ export interface DrandExecuteMsg {
   readonly set_gateway_addr?: { addr: string };
 }
 
+export interface SinkInstantiateMsg {}
+
 export interface GatewayInstantiateMsg {
   readonly manager: string;
   readonly price: Coin;
@@ -82,6 +85,7 @@ export interface NoisContractPaths {
   readonly gateway: string;
   readonly drand: string;
   readonly payment: string;
+  readonly sink: string;
 }
 
 export const wasmContracts: WasmdContractPaths = {
@@ -94,6 +98,7 @@ export const noisContracts: NoisContractPaths = {
   gateway: "./internal/nois_gateway.wasm",
   drand: "./internal/nois_drand.wasm",
   payment: "./internal/nois_payment.wasm",
+  sink: "./internal/nois_sink.wasm",
 };
 
 export async function uploadContracts(

--- a/tests/src/contracts.ts
+++ b/tests/src/contracts.ts
@@ -66,6 +66,7 @@ export interface GatewayExecuteMsg {
     readonly price?: null | Coin;
     readonly drand_addr?: null | string;
     readonly payment_code_id?: null | number;
+    readonly payment_initial_funds?: null | number;
   };
 }
 

--- a/tests/src/contracts.ts
+++ b/tests/src/contracts.ts
@@ -105,11 +105,17 @@ export const noisContracts: NoisContractPaths = {
 export async function uploadContracts(
   t: ExecutionContext,
   cosmwasm: CosmWasmSigner,
-  contracts: WasmdContractPaths | NoisContractPaths
+  contracts: WasmdContractPaths | NoisContractPaths,
+  disable: (keyof WasmdContractPaths | keyof NoisContractPaths)[] = []
 ): Promise<Record<string, number>> {
   const results: Record<string, number> = {};
 
   for (const [name, path] of Object.entries(contracts)) {
+    if ((disable as string[]).includes(name)) {
+      t.log(`Skipping disabled ${name}`);
+      results[name] = Number.NaN;
+      continue;
+    }
     t.log(`Storing ${name} from ${path}...`);
     const wasm = readFileSync(path);
     const multiplier = 1.1; // see https://github.com/cosmos/cosmjs/issues/1360

--- a/tests/src/contracts.ts
+++ b/tests/src/contracts.ts
@@ -50,7 +50,7 @@ export interface GatewayInstantiateMsg {
   readonly manager: string;
   readonly price: Coin;
   readonly payment_code_id: number;
-  readonly payment_initial_funds: Coin;
+  readonly payment_initial_funds?: null | Coin;
   /** Address of the Nois sink */
   readonly sink: string;
 }

--- a/tests/src/contracts.ts
+++ b/tests/src/contracts.ts
@@ -47,6 +47,10 @@ export interface GatewayInstantiateMsg {
   readonly manager: string;
   readonly price: Coin;
   readonly payment_code_id: number;
+  /** Address of the Nois sink */
+  readonly sink: string;
+  /** Address of the Nois community pool */
+  readonly community_pool: string;
 }
 
 export interface GatewayExecuteMsg {

--- a/tests/src/contracts.ts
+++ b/tests/src/contracts.ts
@@ -65,7 +65,6 @@ export interface GatewayExecuteMsg {
     readonly manager?: null | string;
     readonly price?: null | Coin;
     readonly drand_addr?: null | string;
-    readonly payment_code_id?: null | number;
     readonly payment_initial_funds?: null | Coin;
   };
 }

--- a/tests/src/icecube.spec.ts
+++ b/tests/src/icecube.spec.ts
@@ -18,7 +18,7 @@ interface TestContext {
 test.before(async (t) => {
   const noisClient = await setupNoisClient();
   t.log("Upload contracts ...");
-  const noisCodeIds = await uploadContracts(t, noisClient, noisContracts);
+  const noisCodeIds = await uploadContracts(t, noisClient, noisContracts, ["drand", "sink"]);
   const context: TestContext = { noisCodeIds };
   t.context = context;
   t.pass();

--- a/tests/src/payment.spec.ts
+++ b/tests/src/payment.spec.ts
@@ -1,7 +1,6 @@
 import { coin } from "@cosmjs/amino";
 import { fromBinary } from "@cosmjs/cosmwasm-stargate";
 import { fromUtf8 } from "@cosmjs/encoding";
-import { Decimal } from "@cosmjs/math";
 import test from "ava";
 import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
 
@@ -62,8 +61,8 @@ test.serial("payment works", async (t) => {
       processed: { source_id: "drand:dbd506d6ef76e5f386f41c651dcb808c5bcbd75471cc4eafa3f4df7ad4e4c493:800" },
     });
     const commPool2 = await communityPoolFunds(noisClient.sign);
-    const commPoolIncrease = commPool2.minus(commPool1);
-    t.deepEqual(commPoolIncrease, Decimal.fromUserInput("45", 18)); // 45% of the gateway `price`
+    const commPoolIncrease = commPool2 - commPool1;
+    t.deepEqual(commPoolIncrease, 45); // 45% of the gateway `price`
 
     t.log("Relaying DeliverBeacon");
     const info2 = await link.relayAll();
@@ -92,7 +91,7 @@ test.serial("payment works", async (t) => {
       queued: { source_id: "drand:dbd506d6ef76e5f386f41c651dcb808c5bcbd75471cc4eafa3f4df7ad4e4c493:810" },
     });
     const commPool2 = await communityPoolFunds(noisClient.sign);
-    const commPoolIncrease = commPool2.minus(commPool1);
-    t.deepEqual(commPoolIncrease, Decimal.fromUserInput("45", 18)); // 45% of the gateway `price`
+    const commPoolIncrease = commPool2 - commPool1;
+    t.deepEqual(commPoolIncrease, 45); // 45% of the gateway `price`
   }
 });

--- a/tests/src/payment.spec.ts
+++ b/tests/src/payment.spec.ts
@@ -1,0 +1,98 @@
+import { coin } from "@cosmjs/amino";
+import { fromBinary } from "@cosmjs/cosmwasm-stargate";
+import { fromUtf8 } from "@cosmjs/encoding";
+import { Decimal } from "@cosmjs/math";
+import test from "ava";
+import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
+
+import { MockBot } from "./bot";
+import { noisContracts, uploadContracts, wasmContracts } from "./contracts";
+import { instantiateAndConnectIbc, TestContext } from "./setup";
+import { assertPacketsFromA, assertPacketsFromB, communityPoolFunds, setupNoisClient, setupWasmClient } from "./utils";
+
+test.before(async (t) => {
+  const [wasmClient, noisClient] = await Promise.all([setupWasmClient(), setupNoisClient()]);
+  t.log("Upload contracts ...");
+  const [wasmCodeIds, noisCodeIds] = await Promise.all([
+    uploadContracts(t, wasmClient, wasmContracts, ["demo"]),
+    uploadContracts(t, noisClient, noisContracts),
+  ]);
+  const context: TestContext = {
+    wasmCodeIds,
+    noisCodeIds,
+  };
+  t.context = context;
+  t.pass();
+});
+
+test.serial("payment works", async (t) => {
+  const bot = await MockBot.connect();
+  const { wasmClient, noisClient, noisProxyAddress, link, noisGatewayAddress } = await instantiateAndConnectIbc(t, {
+    mockDrandAddr: bot.address,
+    enablePayment: true,
+  });
+  bot.setGatewayAddress(noisGatewayAddress);
+
+  t.log(`Getting randomness prices ...`);
+  const { prices } = await wasmClient.sign.queryContractSmart(noisProxyAddress, { prices: {} });
+  t.log(`All available randomness prices: ${prices.map((p: Coin) => p.amount + p.denom).join(",")}`);
+
+  const { price } = await wasmClient.sign.queryContractSmart(noisProxyAddress, { price: { denom: "ucosm" } });
+  const payment = coin(price, "ucosm");
+  t.log(`Got randomness price from query: ${payment.amount}${payment.denom}`);
+
+  t.log("Executing get_next_randomness for a round that already exists");
+  {
+    await bot.submitNext();
+    await wasmClient.sign.execute(
+      wasmClient.senderAddress,
+      noisProxyAddress,
+      { get_next_randomness: { job_id: "eins" } },
+      "auto",
+      undefined,
+      [payment]
+    );
+
+    t.log("Relaying RequestBeacon");
+    const commPool1 = await communityPoolFunds(noisClient.sign);
+    const info1 = await link.relayAll();
+    assertPacketsFromA(info1, 1, true);
+    const ack1 = JSON.parse(fromUtf8(info1.acksFromB[0].acknowledgement));
+    t.deepEqual(fromBinary(ack1.result), {
+      processed: { source_id: "drand:dbd506d6ef76e5f386f41c651dcb808c5bcbd75471cc4eafa3f4df7ad4e4c493:800" },
+    });
+    const commPool2 = await communityPoolFunds(noisClient.sign);
+    const commPoolIncrease = commPool2.minus(commPool1);
+    t.deepEqual(commPoolIncrease, Decimal.fromUserInput("45", 18)); // 45% of the gateway `price`
+
+    t.log("Relaying DeliverBeacon");
+    const info2 = await link.relayAll();
+    assertPacketsFromB(info2, 1, true);
+    const ack2 = JSON.parse(fromUtf8(info2.acksFromA[0].acknowledgement));
+    t.deepEqual(fromBinary(ack2.result), {});
+  }
+
+  t.log("Executing get_next_randomness for a round that does not yet exists");
+  {
+    await wasmClient.sign.execute(
+      wasmClient.senderAddress,
+      noisProxyAddress,
+      { get_next_randomness: { job_id: "zwei" } },
+      "auto",
+      undefined,
+      [payment]
+    );
+
+    t.log("Relaying RequestBeacon");
+    const commPool1 = await communityPoolFunds(noisClient.sign);
+    const info = await link.relayAll();
+    assertPacketsFromA(info, 1, true);
+    const stdAck = JSON.parse(fromUtf8(info.acksFromB[0].acknowledgement));
+    t.deepEqual(fromBinary(stdAck.result), {
+      queued: { source_id: "drand:dbd506d6ef76e5f386f41c651dcb808c5bcbd75471cc4eafa3f4df7ad4e4c493:810" },
+    });
+    const commPool2 = await communityPoolFunds(noisClient.sign);
+    const commPoolIncrease = commPool2.minus(commPool1);
+    t.deepEqual(commPoolIncrease, Decimal.fromUserInput("45", 18)); // 45% of the gateway `price`
+  }
+});

--- a/tests/src/payment.spec.ts
+++ b/tests/src/payment.spec.ts
@@ -51,10 +51,12 @@ test.serial("payment works", async (t) => {
   const poolAmount = 0.45 * gatewayPrice; // 45% of the gateway `price`
   const relayerAmount = 0.05 * gatewayPrice; // 5% of the gateway `price`
 
-  const { address: paymentAddress } = await noisClient.sign.queryContractSmart(noisGatewayAddress, {
-    payment_address: { channel_id: noisChannel.noisChannelId },
+  const { customer } = await noisClient.sign.queryContractSmart(noisGatewayAddress, {
+    customer: { channel_id: noisChannel.noisChannelId },
   });
-  assert(paymentAddress, "payment address must be set");
+  assert(customer, "customer must be set");
+  const paymentAddress: string = customer.payment;
+  assert(typeof paymentAddress === "string");
 
   const paymentBalanceInitial = await noisClient.sign.getBalance(paymentAddress, "unois");
   t.log(`Initial balance of payment contract ${paymentAddress}: ${printCoin(paymentBalanceInitial)}`);

--- a/tests/src/payment.spec.ts
+++ b/tests/src/payment.spec.ts
@@ -51,11 +51,13 @@ test.serial("payment works", async (t) => {
   const poolAmount = 0.45 * gatewayPrice; // 45% of the gateway `price`
   const relayerAmount = 0.05 * gatewayPrice; // 5% of the gateway `price`
 
-  const { customer } = await noisClient.sign.queryContractSmart(noisGatewayAddress, {
-    customer: { channel_id: noisChannel.noisChannelId },
-  });
-  assert(customer, "customer must be set");
-  const paymentAddress: string = customer.payment;
+  const { payment: paymentAddress, requested_beacons: requested_beacons1 } = await noisClient.sign.queryContractSmart(
+    noisGatewayAddress,
+    {
+      customer: { channel_id: noisChannel.noisChannelId },
+    }
+  );
+  t.is(requested_beacons1, 0);
   assert(typeof paymentAddress === "string");
 
   const paymentBalanceInitial = await noisClient.sign.getBalance(paymentAddress, "unois");
@@ -109,6 +111,11 @@ test.serial("payment works", async (t) => {
     t.deepEqual(ashes[0].burner, paymentAddress);
     t.deepEqual(ashes[0].amount, coin(burnAmount, "unois"));
 
+    const { requested_beacons: requested_beacons2 } = await noisClient.sign.queryContractSmart(noisGatewayAddress, {
+      customer: { channel_id: noisChannel.noisChannelId },
+    });
+    t.is(requested_beacons2, 1);
+
     t.log("Relaying DeliverBeacon");
     const info2 = await link.relayAll();
     assertPacketsFromB(info2, 1, true);
@@ -150,5 +157,10 @@ test.serial("payment works", async (t) => {
     t.deepEqual(ashes.length, 2);
     t.deepEqual(ashes[0].burner, paymentAddress);
     t.deepEqual(ashes[0].amount, coin(burnAmount, "unois"));
+
+    const { requested_beacons: requested_beacons3 } = await noisClient.sign.queryContractSmart(noisGatewayAddress, {
+      customer: { channel_id: noisChannel.noisChannelId },
+    });
+    t.is(requested_beacons3, 2);
   }
 });

--- a/tests/src/payment.spec.ts
+++ b/tests/src/payment.spec.ts
@@ -22,7 +22,7 @@ test.before(async (t) => {
   t.log("Upload contracts ...");
   const [wasmCodeIds, noisCodeIds] = await Promise.all([
     uploadContracts(t, wasmClient, wasmContracts, ["demo"]),
-    uploadContracts(t, noisClient, noisContracts),
+    uploadContracts(t, noisClient, noisContracts, ["icecube"]),
   ]);
   const context: TestContext = {
     wasmCodeIds,

--- a/tests/src/setup.ts
+++ b/tests/src/setup.ts
@@ -93,7 +93,7 @@ export async function instantiateAndConnectIbc(
     manager: noisClient.senderAddress,
     price: coin(options.enablePayment ? 50_000000 : 0, "unois"),
     payment_code_id: context.noisCodeIds.payment,
-    payment_initial_funds: coin(options.enablePayment ? 100_000000 : 0, "unois"), // enough to pay 2 beacon requests
+    payment_initial_funds: options.enablePayment ? coin(100_000000, "unois") : null, // enough to pay 2 beacon requests
     sink: sinkAddress ?? "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt",
   };
   const { contractAddress: noisGatewayAddress } = await noisClient.sign.instantiate(

--- a/tests/src/setup.ts
+++ b/tests/src/setup.ts
@@ -89,9 +89,9 @@ export async function instantiateAndConnectIbc(
   // Instantiate Gateway on Nois
   const instantiateMsg: GatewayInstantiateMsg = {
     manager: noisClient.senderAddress,
-    price: coin(options.enablePayment ? 100 : 0, "unois"),
+    price: coin(options.enablePayment ? 50_000 : 0, "unois"),
     payment_code_id: context.noisCodeIds.payment,
-    payment_initial_funds: coin(options.enablePayment ? 500 : 0, "unois"), // enough to pay 5 beacon requests
+    payment_initial_funds: coin(options.enablePayment ? 100_000 : 0, "unois"), // enough to pay 2 beacon requests
     sink: sinkAddress ?? "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt",
   };
   const { contractAddress: noisGatewayAddress } = await noisClient.sign.instantiate(
@@ -102,7 +102,7 @@ export async function instantiateAndConnectIbc(
     "auto"
   );
   if (options.enablePayment) {
-    await fundAccount(nois, noisGatewayAddress, "1500"); // 1500 unois can fund 3 payment contracts
+    await fundAccount(nois, noisGatewayAddress, "100000"); // 100000 unois can fund 1 payment contracts
   }
 
   const setDrandMsg: GatewayExecuteMsg = { set_config: { drand_addr: options.mockDrandAddr } };

--- a/tests/src/setup.ts
+++ b/tests/src/setup.ts
@@ -35,11 +35,11 @@ export interface SetupInfo {
   link: Link;
   noisChannel: {
     wasmChannelId: string;
-    osmoChannelId: string;
+    noisChannelId: string;
   };
   ics20Channel: {
     wasmChannelId: string;
-    osmoChannelId: string;
+    noisChannelId: string;
   };
 }
 
@@ -125,7 +125,7 @@ export async function instantiateAndConnectIbc(
   const info = await link.createChannel("A", proxyPort, gatewayPort, Order.ORDER_UNORDERED, NoisProtocolIbcVersion);
   const noisChannel = {
     wasmChannelId: info.src.channelId,
-    osmoChannelId: info.dest.channelId,
+    noisChannelId: info.dest.channelId,
   };
   const info2 = await link.relayAll();
   assertPacketsFromB(info2, 1, true); // Welcome packet
@@ -134,7 +134,7 @@ export async function instantiateAndConnectIbc(
   const ics20Info = await link.createChannel("A", wasmd.ics20Port, nois.ics20Port, Order.ORDER_UNORDERED, "ics20-1");
   const ics20Channel = {
     wasmChannelId: ics20Info.src.channelId,
-    osmoChannelId: ics20Info.dest.channelId,
+    noisChannelId: ics20Info.dest.channelId,
   };
 
   // Instantiate demo app

--- a/tests/src/setup.ts
+++ b/tests/src/setup.ts
@@ -41,6 +41,8 @@ export interface SetupInfo {
     wasmChannelId: string;
     noisChannelId: string;
   };
+  realyerWasm: string;
+  realyerNois: string;
 }
 
 export interface InstantiateAndConnectOptions {
@@ -89,9 +91,9 @@ export async function instantiateAndConnectIbc(
   // Instantiate Gateway on Nois
   const instantiateMsg: GatewayInstantiateMsg = {
     manager: noisClient.senderAddress,
-    price: coin(options.enablePayment ? 50_000 : 0, "unois"),
+    price: coin(options.enablePayment ? 50_000000 : 0, "unois"),
     payment_code_id: context.noisCodeIds.payment,
-    payment_initial_funds: coin(options.enablePayment ? 100_000 : 0, "unois"), // enough to pay 2 beacon requests
+    payment_initial_funds: coin(options.enablePayment ? 100_000000 : 0, "unois"), // enough to pay 2 beacon requests
     sink: sinkAddress ?? "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt",
   };
   const { contractAddress: noisGatewayAddress } = await noisClient.sign.instantiate(
@@ -102,7 +104,7 @@ export async function instantiateAndConnectIbc(
     "auto"
   );
   if (options.enablePayment) {
-    await fundAccount(nois, noisGatewayAddress, "100000"); // 100000 unois can fund 1 payment contracts
+    await fundAccount(nois, noisGatewayAddress, "100000000"); // 100 NOIS can fund 1 payment contracts
   }
 
   const setDrandMsg: GatewayExecuteMsg = { set_config: { drand_addr: options.mockDrandAddr } };
@@ -119,6 +121,7 @@ export async function instantiateAndConnectIbc(
 
   // Create a connection between the chains
   const [src, dest] = await setup(wasmd, nois);
+  dest.senderAddress;
   const link = await Link.createWithNewConnections(src, dest);
 
   // Create a channel for the Nois protocol
@@ -160,5 +163,7 @@ export async function instantiateAndConnectIbc(
     link,
     noisChannel,
     ics20Channel,
+    realyerWasm: src.senderAddress,
+    realyerNois: dest.senderAddress,
   };
 }

--- a/tests/src/setup.ts
+++ b/tests/src/setup.ts
@@ -30,6 +30,8 @@ export interface SetupInfo {
   noisDemoAddress: string | undefined;
   /// Address on Nois
   noisGatewayAddress: string;
+  /// Address on Nois
+  sinkAddress: string | undefined;
   link: Link;
   noisChannel: {
     wasmChannelId: string;
@@ -154,6 +156,7 @@ export async function instantiateAndConnectIbc(
     noisProxyAddress,
     noisDemoAddress,
     noisGatewayAddress,
+    sinkAddress,
     link,
     noisChannel,
     ics20Channel,

--- a/tests/src/setup.ts
+++ b/tests/src/setup.ts
@@ -1,0 +1,150 @@
+import { CosmWasmSigner, Link, testutils } from "@confio/relayer";
+import { coin, coins } from "@cosmjs/amino";
+import { assert } from "@cosmjs/utils";
+import { ExecutionContext } from "ava";
+import { Order } from "cosmjs-types/ibc/core/channel/v1/channel";
+
+import {
+  GatewayExecuteMsg,
+  GatewayInstantiateMsg,
+  NoisContractPaths,
+  ProxyInstantiateMsg,
+  SinkInstantiateMsg,
+  WasmdContractPaths,
+} from "./contracts";
+import { assertPacketsFromB, nois, NoisProtocolIbcVersion, setupNoisClient, setupWasmClient } from "./utils";
+
+const { setup, wasmd, fundAccount } = testutils;
+
+export interface TestContext {
+  wasmCodeIds: Record<keyof WasmdContractPaths, number>;
+  noisCodeIds: Record<keyof NoisContractPaths, number>;
+}
+
+export interface SetupInfo {
+  wasmClient: CosmWasmSigner;
+  noisClient: CosmWasmSigner;
+  /// Address on app chain (wasmd)
+  noisProxyAddress: string;
+  /// Address on app chain (wasmd)
+  noisDemoAddress: string;
+  /// Address on Nois
+  noisGatewayAddress: string;
+  link: Link;
+  noisChannel: {
+    wasmChannelId: string;
+    osmoChannelId: string;
+  };
+  ics20Channel: {
+    wasmChannelId: string;
+    osmoChannelId: string;
+  };
+}
+
+export interface InstantiateAndConnectOptions {
+  readonly testMode?: boolean;
+  readonly mockDrandAddr: string;
+  readonly callback_gas_limit?: number;
+}
+
+export async function instantiateAndConnectIbc(
+  t: ExecutionContext,
+  options: InstantiateAndConnectOptions
+): Promise<SetupInfo> {
+  const context = t.context as TestContext;
+  const [wasmClient, noisClient] = await Promise.all([setupWasmClient(), setupNoisClient()]);
+
+  // Instantiate proxy on appchain
+  const proxyMsg: ProxyInstantiateMsg = {
+    prices: coins(1_000_000, "ucosm"),
+    withdrawal_address: wasmClient.senderAddress,
+    test_mode: options.testMode ?? true,
+    callback_gas_limit: options.callback_gas_limit ?? 500_000,
+  };
+  const { contractAddress: noisProxyAddress } = await wasmClient.sign.instantiate(
+    wasmClient.senderAddress,
+    context.wasmCodeIds.proxy,
+    proxyMsg,
+    "Proxy instance",
+    "auto"
+  );
+
+  // Instantiate sink on Nois
+  const sinkMsg: SinkInstantiateMsg = {};
+  const { contractAddress: sinkAddress } = await noisClient.sign.instantiate(
+    noisClient.senderAddress,
+    context.noisCodeIds.sink,
+    sinkMsg,
+    "Sink instance",
+    "auto"
+  );
+
+  // Instantiate Gateway on Nois
+  const instantiateMsg: GatewayInstantiateMsg = {
+    manager: noisClient.senderAddress,
+    price: coin(100, "unois"),
+    payment_code_id: context.noisCodeIds.payment,
+    payment_initial_funds: coin(500, "unois"), // enough to pay 5 beacon requests
+    sink: sinkAddress,
+  };
+  const { contractAddress: noisGatewayAddress } = await noisClient.sign.instantiate(
+    noisClient.senderAddress,
+    context.noisCodeIds.gateway,
+    instantiateMsg,
+    "Gateway instance",
+    "auto"
+  );
+  await fundAccount(nois, noisGatewayAddress, "1500"); // 1500 unois can fund 3 payment contracts
+
+  const setDrandMsg: GatewayExecuteMsg = { set_config: { drand_addr: options.mockDrandAddr } };
+  await noisClient.sign.execute(noisClient.senderAddress, noisGatewayAddress, setDrandMsg, "auto");
+
+  const [noisProxyInfo, noisGatewayInfo] = await Promise.all([
+    wasmClient.sign.getContract(noisProxyAddress),
+    noisClient.sign.getContract(noisGatewayAddress),
+  ]);
+  const { ibcPortId: proxyPort } = noisProxyInfo;
+  assert(proxyPort);
+  const { ibcPortId: gatewayPort } = noisGatewayInfo;
+  assert(gatewayPort);
+
+  // Create a connection between the chains
+  const [src, dest] = await setup(wasmd, nois);
+  const link = await Link.createWithNewConnections(src, dest);
+
+  // Create a channel for the Nois protocol
+  const info = await link.createChannel("A", proxyPort, gatewayPort, Order.ORDER_UNORDERED, NoisProtocolIbcVersion);
+  const noisChannel = {
+    wasmChannelId: info.src.channelId,
+    osmoChannelId: info.dest.channelId,
+  };
+  const info2 = await link.relayAll();
+  assertPacketsFromB(info2, 1, true); // Welcome packet
+
+  // Also create a ics20 channel
+  const ics20Info = await link.createChannel("A", wasmd.ics20Port, nois.ics20Port, Order.ORDER_UNORDERED, "ics20-1");
+  const ics20Channel = {
+    wasmChannelId: ics20Info.src.channelId,
+    osmoChannelId: ics20Info.dest.channelId,
+  };
+
+  // Instantiate demo app
+  const { contractAddress: noisDemoAddress } = await wasmClient.sign.instantiate(
+    wasmClient.senderAddress,
+    context.wasmCodeIds.demo,
+    { nois_proxy: noisProxyAddress },
+    "A demo contract",
+    "auto"
+  );
+
+  return {
+    wasmClient,
+    noisClient,
+    noisProxyAddress,
+    noisDemoAddress,
+    noisGatewayAddress,
+    link,
+    noisChannel,
+    ics20Channel,
+  };
+}

--- a/tests/src/tests.spec.ts
+++ b/tests/src/tests.spec.ts
@@ -14,6 +14,7 @@ import {
   NoisContractPaths,
   noisContracts,
   ProxyInstantiateMsg,
+  SinkInstantiateMsg,
   uploadContracts,
   wasmContracts,
   WasmdContractPaths,
@@ -77,6 +78,7 @@ test.serial("set up channel", async (t) => {
     manager: noisClient.senderAddress,
     price: coin(0, "unois"),
     payment_code_id: context.noisCodeIds.payment,
+    // any dummy address is good here because we only test channel creation
     sink: "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt",
   };
   const { contractAddress: gatewayAddress } = await noisClient.sign.instantiate(
@@ -146,12 +148,22 @@ async function instantiateAndConnectIbc(
     "auto"
   );
 
+  // Instantiate sink on Nois
+  const sinkMsg: SinkInstantiateMsg = {};
+  const { contractAddress: sinkAddress } = await noisClient.sign.instantiate(
+    noisClient.senderAddress,
+    context.noisCodeIds.sink,
+    sinkMsg,
+    "Sink instance",
+    "auto"
+  );
+
   // Instantiate Gateway on Nois
   const instantiateMsg: GatewayInstantiateMsg = {
     manager: noisClient.senderAddress,
     price: coin(0, "unois"),
     payment_code_id: context.noisCodeIds.payment,
-    sink: "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt",
+    sink: sinkAddress,
   };
   const { contractAddress: noisGatewayAddress } = await noisClient.sign.instantiate(
     noisClient.senderAddress,

--- a/tests/src/tests.spec.ts
+++ b/tests/src/tests.spec.ts
@@ -95,6 +95,8 @@ test.serial("set up channel", async (t) => {
   const [src, dest] = await setup(wasmd, nois);
   const link = await Link.createWithNewConnections(src, dest);
   await link.createChannel("A", proxyPort, gatewayPort, Order.ORDER_UNORDERED, NoisProtocolIbcVersion);
+  const info2 = await link.relayAll();
+  assertPacketsFromB(info2, 1, true); // Welcome packet
 });
 
 interface SetupInfo {
@@ -183,6 +185,8 @@ async function instantiateAndConnectIbc(
     wasmChannelId: info.src.channelId,
     osmoChannelId: info.dest.channelId,
   };
+  const info2 = await link.relayAll();
+  assertPacketsFromB(info2, 1, true); // Welcome packet
 
   // Also create a ics20 channel
   const ics20Info = await link.createChannel("A", wasmd.ics20Port, nois.ics20Port, Order.ORDER_UNORDERED, "ics20-1");

--- a/tests/src/tests.spec.ts
+++ b/tests/src/tests.spec.ts
@@ -50,6 +50,8 @@ test.before(async (t) => {
 });
 
 test.serial("set up channel", async (t) => {
+  const context = t.context as TestContext;
+
   // Instantiate proxy on appchain
   const wasmClient = await setupWasmClient();
   const proxyMsg: ProxyInstantiateMsg = {
@@ -60,7 +62,7 @@ test.serial("set up channel", async (t) => {
   };
   const { contractAddress: proxyAddress } = await wasmClient.sign.instantiate(
     wasmClient.senderAddress,
-    (t.context as TestContext).wasmCodeIds.proxy,
+    context.wasmCodeIds.proxy,
     proxyMsg,
     "Proxy instance",
     "auto"
@@ -74,10 +76,11 @@ test.serial("set up channel", async (t) => {
   const msg: GatewayInstantiateMsg = {
     manager: noisClient.senderAddress,
     price: coins(1_000_000, "unois")[0],
+    payment_code_id: context.noisCodeIds.payment,
   };
   const { contractAddress: gatewayAddress } = await noisClient.sign.instantiate(
     noisClient.senderAddress,
-    (t.context as TestContext).noisCodeIds.gateway,
+    context.noisCodeIds.gateway,
     msg,
     "Gateway instance",
     "auto"
@@ -122,6 +125,7 @@ async function instantiateAndConnectIbc(
   t: ExecutionContext,
   options: InstantiateAndConnectOptions
 ): Promise<SetupInfo> {
+  const context = t.context as TestContext;
   const [wasmClient, noisClient] = await Promise.all([setupWasmClient(), setupNoisClient()]);
 
   // Instantiate proxy on appchain
@@ -143,10 +147,11 @@ async function instantiateAndConnectIbc(
   const instantiateMsg: GatewayInstantiateMsg = {
     manager: noisClient.senderAddress,
     price: coins(1_000_000, "unois")[0],
+    payment_code_id: context.noisCodeIds.payment,
   };
   const { contractAddress: noisGatewayAddress } = await noisClient.sign.instantiate(
     noisClient.senderAddress,
-    (t.context as TestContext).noisCodeIds.gateway,
+    context.noisCodeIds.gateway,
     instantiateMsg,
     "Gateway instance",
     "auto"
@@ -185,7 +190,7 @@ async function instantiateAndConnectIbc(
   // Instantiate demo app
   const { contractAddress: noisDemoAddress } = await wasmClient.sign.instantiate(
     wasmClient.senderAddress,
-    (t.context as TestContext).wasmCodeIds.demo,
+    context.wasmCodeIds.demo,
     { nois_proxy: noisProxyAddress },
     "A demo contract",
     "auto"

--- a/tests/src/tests.spec.ts
+++ b/tests/src/tests.spec.ts
@@ -75,7 +75,7 @@ test.serial("set up channel", async (t) => {
   const noisClient = await setupNoisClient();
   const msg: GatewayInstantiateMsg = {
     manager: noisClient.senderAddress,
-    price: coins(1_000_000, "unois")[0],
+    price: coin(0, "unois"),
     payment_code_id: context.noisCodeIds.payment,
     sink: "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt",
     community_pool: "nois1uw8c69maprjq5ure7x80x9nauasrn7why5dfwd",
@@ -148,7 +148,7 @@ async function instantiateAndConnectIbc(
   // Instantiate Gateway on Nois
   const instantiateMsg: GatewayInstantiateMsg = {
     manager: noisClient.senderAddress,
-    price: coins(1_000_000, "unois")[0],
+    price: coin(0, "unois"),
     payment_code_id: context.noisCodeIds.payment,
     sink: "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt",
     community_pool: "nois1uw8c69maprjq5ure7x80x9nauasrn7why5dfwd",

--- a/tests/src/tests.spec.ts
+++ b/tests/src/tests.spec.ts
@@ -78,6 +78,7 @@ test.serial("set up channel", async (t) => {
     manager: noisClient.senderAddress,
     price: coin(0, "unois"),
     payment_code_id: context.noisCodeIds.payment,
+    payment_initial_funds: coin(0, "unois"),
     // any dummy address is good here because we only test channel creation
     sink: "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt",
   };
@@ -161,8 +162,9 @@ async function instantiateAndConnectIbc(
   // Instantiate Gateway on Nois
   const instantiateMsg: GatewayInstantiateMsg = {
     manager: noisClient.senderAddress,
-    price: coin(0, "unois"),
+    price: coin(50, "unois"),
     payment_code_id: context.noisCodeIds.payment,
+    payment_initial_funds: coin(200, "unois"),
     sink: sinkAddress,
   };
   const { contractAddress: noisGatewayAddress } = await noisClient.sign.instantiate(
@@ -172,6 +174,7 @@ async function instantiateAndConnectIbc(
     "Gateway instance",
     "auto"
   );
+  await fundAccount(nois, noisGatewayAddress, "1000"); // 1000 unois can fund 5 payment contracts
 
   const setDrandMsg: GatewayExecuteMsg = { set_config: { drand_addr: options.mockDrandAddr } };
   await noisClient.sign.execute(noisClient.senderAddress, noisGatewayAddress, setDrandMsg, "auto");

--- a/tests/src/tests.spec.ts
+++ b/tests/src/tests.spec.ts
@@ -77,6 +77,8 @@ test.serial("set up channel", async (t) => {
     manager: noisClient.senderAddress,
     price: coins(1_000_000, "unois")[0],
     payment_code_id: context.noisCodeIds.payment,
+    sink: "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt",
+    community_pool: "nois1uw8c69maprjq5ure7x80x9nauasrn7why5dfwd",
   };
   const { contractAddress: gatewayAddress } = await noisClient.sign.instantiate(
     noisClient.senderAddress,
@@ -148,6 +150,8 @@ async function instantiateAndConnectIbc(
     manager: noisClient.senderAddress,
     price: coins(1_000_000, "unois")[0],
     payment_code_id: context.noisCodeIds.payment,
+    sink: "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt",
+    community_pool: "nois1uw8c69maprjq5ure7x80x9nauasrn7why5dfwd",
   };
   const { contractAddress: noisGatewayAddress } = await noisClient.sign.instantiate(
     noisClient.senderAddress,

--- a/tests/src/tests.spec.ts
+++ b/tests/src/tests.spec.ts
@@ -64,7 +64,7 @@ test.serial("set up channel", async (t) => {
     manager: noisClient.senderAddress,
     price: coin(0, "unois"),
     payment_code_id: context.noisCodeIds.payment,
-    payment_initial_funds: coin(0, "unois"),
+    payment_initial_funds: null,
     // any dummy address is good here because we only test channel creation
     sink: "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt",
   };

--- a/tests/src/tests.spec.ts
+++ b/tests/src/tests.spec.ts
@@ -78,7 +78,6 @@ test.serial("set up channel", async (t) => {
     price: coin(0, "unois"),
     payment_code_id: context.noisCodeIds.payment,
     sink: "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt",
-    community_pool: "nois1uw8c69maprjq5ure7x80x9nauasrn7why5dfwd",
   };
   const { contractAddress: gatewayAddress } = await noisClient.sign.instantiate(
     noisClient.senderAddress,
@@ -153,7 +152,6 @@ async function instantiateAndConnectIbc(
     price: coin(0, "unois"),
     payment_code_id: context.noisCodeIds.payment,
     sink: "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt",
-    community_pool: "nois1uw8c69maprjq5ure7x80x9nauasrn7why5dfwd",
   };
   const { contractAddress: noisGatewayAddress } = await noisClient.sign.instantiate(
     noisClient.senderAddress,

--- a/tests/src/utils.ts
+++ b/tests/src/utils.ts
@@ -34,7 +34,7 @@ export const noisValidator = {
   address: "noisvaloper13k69ev2re0vlk952cf8cnuua5znhvv7dvrayrm",
 };
 
-export const NoisProtocolIbcVersion = "nois-v5";
+export const NoisProtocolIbcVersion = "nois-v6";
 
 // This creates a client for the CosmWasm chain, that can interact with contracts
 export async function setupWasmClient(): Promise<CosmWasmSigner> {

--- a/tests/src/utils.ts
+++ b/tests/src/utils.ts
@@ -2,7 +2,6 @@ import { AckWithMetadata, CosmWasmSigner, RelayInfo, testutils } from "@confio/r
 import { ChainDefinition } from "@confio/relayer/build/lib/helpers";
 import { fromBinary, SigningCosmWasmClient } from "@cosmjs/cosmwasm-stargate";
 import { fromUtf8 } from "@cosmjs/encoding";
-import { Decimal } from "@cosmjs/math";
 import { decodeCosmosSdkDecFromProto, QueryClient, setupDistributionExtension } from "@cosmjs/stargate";
 import { assert } from "@cosmjs/utils";
 
@@ -31,16 +30,17 @@ export const nois: ChainDefinition = {
   estimatedIndexerTime: 80,
 };
 
-export async function communityPoolFunds(client: SigningCosmWasmClient): Promise<Decimal> {
+/* Queries the community pool funds in full unois. */
+export async function communityPoolFunds(client: SigningCosmWasmClient): Promise<number> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const tmClient = (client as any).forceGetTmClient();
   const queryClient = QueryClient.withExtensions(tmClient, setupDistributionExtension);
   const resp = await queryClient.distribution.communityPool();
   const unois = resp.pool.find((coin) => coin.denom === "unois");
   if (!unois) {
-    return Decimal.zero(18);
+    return 0;
   } else {
-    return decodeCosmosSdkDecFromProto(unois.amount);
+    return decodeCosmosSdkDecFromProto(unois.amount).floor().toFloatApproximation();
   }
 }
 

--- a/tests/src/utils.ts
+++ b/tests/src/utils.ts
@@ -2,7 +2,13 @@ import { AckWithMetadata, CosmWasmSigner, RelayInfo, testutils } from "@confio/r
 import { ChainDefinition } from "@confio/relayer/build/lib/helpers";
 import { fromBinary, SigningCosmWasmClient } from "@cosmjs/cosmwasm-stargate";
 import { fromUtf8 } from "@cosmjs/encoding";
-import { decodeCosmosSdkDecFromProto, QueryClient, setupDistributionExtension } from "@cosmjs/stargate";
+import {
+  Coin,
+  decodeCosmosSdkDecFromProto,
+  QueryClient,
+  setupBankExtension,
+  setupDistributionExtension,
+} from "@cosmjs/stargate";
 import { assert } from "@cosmjs/utils";
 
 const { fundAccount, generateMnemonic, signingCosmWasmClient, wasmd } = testutils;
@@ -42,6 +48,14 @@ export async function communityPoolFunds(client: SigningCosmWasmClient): Promise
   } else {
     return decodeCosmosSdkDecFromProto(unois.amount).floor().toFloatApproximation();
   }
+}
+
+/* Queries the community pool funds in full unois. */
+export async function totalSupply(client: SigningCosmWasmClient): Promise<Coin> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const tmClient = (client as any).forceGetTmClient();
+  const queryClient = QueryClient.withExtensions(tmClient, setupBankExtension);
+  return queryClient.bank.supplyOf("unois");
 }
 
 export const noisValidator = {

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
+    "target": "es2020",
     "lib": ["es2020"],
     "moduleResolution": "node",
     "incremental": true,


### PR DESCRIPTION
Closes #156

- [x] Use MsgFundCommunityPool instead of bank send to fund the community pool
- [x] Use real sink in tests
- [x] Test usage of MsgFundCommunityPool with non-0 amount
- [x] Add missing query for PAYMENT_ADDRESSES
- [x] Make payment_initial_funds upgradable
- [x] Test funding changes in integration tests
    - [x] community pool +45unois
    - [x] sink burn log 50unois
    - [x] relayer 5unois
    - [x] payment contract -100unois