### PR TITLE
Add proto encoder to create MsgFundCommunityPool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,7 @@ dependencies = [
 name = "nois-payment"
 version = "0.11.0"
 dependencies = [
+ "anything",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
+name = "anything"
+version = "0.11.0"
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/nois-gateway/src/contract.rs
+++ b/contracts/nois-gateway/src/contract.rs
@@ -32,12 +32,10 @@ pub fn instantiate(
         manager,
         payment_code_id,
         sink,
-        community_pool,
     } = msg;
 
     let manager = deps.api.addr_validate(&manager)?;
     let sink = deps.api.addr_validate(&sink)?;
-    let community_pool = deps.api.addr_validate(&community_pool)?;
 
     ensure_code_id_exists(deps.as_ref(), payment_code_id)?;
 
@@ -47,7 +45,6 @@ pub fn instantiate(
         price,
         payment_code_id,
         sink,
-        community_pool,
     };
     CONFIG.save(deps.storage, &config)?;
     Ok(Response::default())
@@ -172,7 +169,6 @@ pub fn ibc_channel_connect(
         label: format!("For {chan_id}"),
         msg: to_binary(&nois_payment::msg::InstantiateMsg {
             sink: config.sink.into(),
-            community_pool: config.community_pool.into(),
         })?,
         funds: vec![],
         salt,
@@ -393,8 +389,7 @@ fn execute_set_config(
         drand,
         price,
         payment_code_id,
-        sink: config.sink,                     // TODO: make updatable?
-        community_pool: config.community_pool, // TODO: make updatable?
+        sink: config.sink, // TODO: make updatable?
     };
 
     CONFIG.save(deps.storage, &new_config)?;
@@ -447,7 +442,6 @@ mod tests {
     const PAYMENT: u64 = 33;
     const PAYMENT2: u64 = 37;
     const SINK: &str = "sink";
-    const COMMUNOTY_POOL: &str = "community_pool";
 
     // Consecutive timestamps for the rounds 810, 820, 830, 840
     const AFTER1: Timestamp = Timestamp::from_seconds(1677687627 - 1);
@@ -466,7 +460,6 @@ mod tests {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: SINK.to_string(),
-            community_pool: COMMUNOTY_POOL.to_string(),
         };
         let info = mock_info(CREATOR, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -688,7 +681,6 @@ mod tests {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: SINK.to_string(),
-            community_pool: COMMUNOTY_POOL.to_string(),
         };
         let info = mock_info("creator", &[]);
         let env = mock_env();
@@ -705,7 +697,6 @@ mod tests {
                 price: Coin::new(1, "unois"),
                 payment_code_id: PAYMENT,
                 sink: Addr::unchecked(SINK),
-                community_pool: Addr::unchecked(COMMUNOTY_POOL),
             }
         );
     }
@@ -719,7 +710,6 @@ mod tests {
             price: Coin::new(1, "unois"),
             payment_code_id: 654321,
             sink: SINK.to_string(),
-            community_pool: COMMUNOTY_POOL.to_string(),
         };
         let info = mock_info("creator", &[]);
         let env = mock_env();
@@ -743,7 +733,6 @@ mod tests {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: SINK.to_string(),
-            community_pool: COMMUNOTY_POOL.to_string(),
         };
         let info = mock_info("creator", &[]);
         let env = mock_env();
@@ -782,7 +771,6 @@ mod tests {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: SINK.to_string(),
-            community_pool: COMMUNOTY_POOL.to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -826,7 +814,6 @@ mod tests {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: SINK.to_string(),
-            community_pool: COMMUNOTY_POOL.to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -990,7 +977,6 @@ mod tests {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: SINK.to_string(),
-            community_pool: COMMUNOTY_POOL.to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 

--- a/contracts/nois-gateway/src/msg.rs
+++ b/contracts/nois-gateway/src/msg.rs
@@ -11,8 +11,6 @@ pub struct InstantiateMsg {
     pub payment_code_id: u64,
     /// Address of the Nois sink
     pub sink: String,
-    /// Address of the Nois community pool
-    pub community_pool: String,
 }
 
 #[cw_serde]

--- a/contracts/nois-gateway/src/state.rs
+++ b/contracts/nois-gateway/src/state.rs
@@ -15,8 +15,6 @@ pub struct Config {
     pub payment_code_id: u64,
     /// Address of the Nois sink
     pub sink: Addr,
-    /// Address of the Nois community pool
-    pub community_pool: Addr,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");

--- a/contracts/nois-payment/Cargo.toml
+++ b/contracts/nois-payment/Cargo.toml
@@ -17,9 +17,10 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { version = "1.2.3" }
+cosmwasm-std = { version = "1.2.3", features = ["stargate"] }
 cosmwasm-schema = { version = "1.2.3" }
 cw-storage-plus = { version = "1.0.0" }
+anything = { path = "../../packages/anything" }
 nois.workspace = true
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }

--- a/contracts/nois-payment/src/contract.rs
+++ b/contracts/nois-payment/src/contract.rs
@@ -123,7 +123,7 @@ fn execute_pay(
             .append_bytes(1, &community_pool.denom)
             .append_bytes(2, community_pool.amount.to_string());
         let msg_fund_community_pool = Anything::new()
-            .append_anything(1, &coin)
+            .append_message(1, &coin)
             .append_bytes(2, env.contract.address.as_bytes())
             .into_vec();
         out_msgs.push(CosmosMsg::Stargate {

--- a/contracts/nois-payment/src/contract.rs
+++ b/contracts/nois-payment/src/contract.rs
@@ -19,14 +19,9 @@ pub fn instantiate(
         .api
         .addr_validate(&msg.sink)
         .map_err(|_| ContractError::InvalidAddress)?;
-    let nois_com_pool_addr = deps
-        .api
-        .addr_validate(&msg.community_pool)
-        .map_err(|_| ContractError::InvalidAddress)?;
     CONFIG.save(
         deps.storage,
         &Config {
-            community_pool: nois_com_pool_addr,
             sink: nois_sink_addr,
             gateway: info.sender.clone(),
         },
@@ -34,7 +29,6 @@ pub fn instantiate(
     Ok(Response::new()
         .add_attribute("action", "instantiate")
         .add_attribute("nois_sink", msg.sink)
-        .add_attribute("nois_community_pool", msg.community_pool)
         .add_attribute("nois_gateway", info.sender))
 }
 
@@ -153,7 +147,6 @@ mod tests {
     };
 
     const NOIS_SINK: &str = "sink";
-    const NOIS_COMMUNITY_POOL: &str = "community_pool";
     const NOIS_GATEWAY: &str = "nois-gateway";
 
     /// Gets the value of the first attribute with the given key
@@ -172,7 +165,6 @@ mod tests {
         let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
             sink: NOIS_SINK.to_string(),
-            community_pool: NOIS_COMMUNITY_POOL.to_string(),
         };
         let info = mock_info(NOIS_GATEWAY, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -182,7 +174,6 @@ mod tests {
         assert_eq!(
             config,
             ConfigResponse {
-                community_pool: Addr::unchecked(NOIS_COMMUNITY_POOL),
                 sink: Addr::unchecked(NOIS_SINK),
                 gateway: Addr::unchecked(NOIS_GATEWAY),
             }
@@ -194,7 +185,6 @@ mod tests {
         let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
             sink: NOIS_SINK.to_string(),
-            community_pool: NOIS_COMMUNITY_POOL.to_string(),
         };
         let info = mock_info(NOIS_GATEWAY, &[]);
         let _result = instantiate(deps.as_mut(), mock_env(), info, msg);
@@ -227,7 +217,6 @@ mod tests {
         let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
             sink: NOIS_SINK.to_string(),
-            community_pool: NOIS_COMMUNITY_POOL.to_string(),
         };
         let info = mock_info(NOIS_GATEWAY, &[]);
         let _result = instantiate(deps.as_mut(), mock_env(), info, msg);
@@ -260,7 +249,6 @@ mod tests {
         let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
             sink: NOIS_SINK.to_string(),
-            community_pool: NOIS_COMMUNITY_POOL.to_string(),
         };
         let info = mock_info(NOIS_GATEWAY, &[]);
         let _result = instantiate(deps.as_mut(), mock_env(), info, msg);

--- a/contracts/nois-payment/src/msg.rs
+++ b/contracts/nois-payment/src/msg.rs
@@ -7,8 +7,6 @@ use crate::state::Config;
 pub struct InstantiateMsg {
     /// Address of the Nois sink
     pub sink: String,
-    /// Address of the Nois community pool
-    pub community_pool: String,
 }
 
 #[cw_serde]

--- a/contracts/nois-payment/src/state.rs
+++ b/contracts/nois-payment/src/state.rs
@@ -6,8 +6,6 @@ use cw_storage_plus::Item;
 pub struct Config {
     /// The address of the sink contract to burn the used tokens.
     pub sink: Addr,
-    /// The address of the community pool.
-    pub community_pool: Addr,
     /// The address of nois-gateway
     pub gateway: Addr,
 }

--- a/packages/anything/Cargo.toml
+++ b/packages/anything/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "anything"
+version = "0.11.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[dev-dependencies]

--- a/packages/anything/src/lib.rs
+++ b/packages/anything/src/lib.rs
@@ -1,0 +1,150 @@
+//! A minimal (like seriously), zero dependency protobuf encoder.
+//!
+//! Supported:
+//! - Varint (u64)
+//! - Repeated: Just append a field multiple times
+//! - Nested: Just append an `Anything` instance
+//!
+//! Non supported:
+//!
+//! - Fixed length types
+//! - Field sorting
+
+#[derive(Default)]
+pub struct Anything {
+    output: Vec<u8>,
+}
+
+/// The protobuf wire types
+///
+/// <https://protobuf.dev/programming-guides/encoding/#structure>
+#[repr(u32)]
+enum WireType {
+    /// Variable length field (int32, int64, uint32, uint64, sint32, sint64, bool, enum)
+    Varint = 0,
+    // Fixed length types unsupported
+    // I64 = 1,
+    /// Lengths prefixed field (string, bytes, embedded messages, packed repeated fields)
+    Len = 2,
+    // group start/end (deprecated, unsupported)
+    // SGROUP = 3,
+    // EGROUP = 4,
+    // Fixed length types unsupported
+    // I32 = 5,
+}
+
+fn varint_encode(mut n: u64, dest: &mut Vec<u8>) {
+    let mut buf = [0u8; 10];
+    let mut len = 0;
+    loop {
+        // Read least significant 7 bits
+        let mut b = (n & 0b0111_1111) as u8;
+        n >>= 7;
+        // Set top bit when not yet done
+        if n != 0 {
+            b |= 0b1000_0000;
+        }
+        buf[len] = b;
+        len += 1;
+        if n == 0 {
+            break;
+        }
+    }
+    dest.extend_from_slice(&buf[0..len]);
+}
+
+impl Anything {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn append_bytes(mut self, field_number: u32, data: impl AsRef<[u8]>) -> Self {
+        let data = data.as_ref();
+        if data.is_empty() {
+            return self;
+        }
+        // tag
+        self.append_tag(field_number, WireType::Len);
+        // length
+        varint_encode(data.len() as u64, &mut self.output);
+        // value
+        self.output.extend_from_slice(data);
+        self
+    }
+
+    pub fn append_u64(mut self, field_number: u32, value: u64) -> Self {
+        if value == 0 {
+            return self;
+        }
+        self.append_tag(field_number, WireType::Varint);
+        varint_encode(value, &mut self.output);
+        self
+    }
+
+    pub fn append_anything(self, field_number: u32, value: &Anything) -> Self {
+        self.append_bytes(field_number, value.as_bytes())
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.output
+    }
+
+    /// Takes the instance and returns the protobuf bytes
+    pub fn into_vec(self) -> Vec<u8> {
+        self.output
+    }
+
+    fn append_tag(&mut self, field_number: u32, field_type: WireType) {
+        let tag: u32 = (field_number << 3) | field_type as u32;
+        varint_encode(tag as u64, &mut self.output);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_returns_empty_data() {
+        let data = Anything::new();
+        assert_eq!(data.into_vec(), &[]);
+    }
+
+    #[test]
+    fn append_u64() {
+        let data = Anything::new().append_u64(1, 150);
+        assert_eq!(data.into_vec(), [0b00001000, 0b10010110, 0b00000001]);
+
+        // Zero/Default field not written
+        let data = Anything::new().append_u64(1, 0);
+        assert_eq!(data.into_vec(), &[]);
+    }
+
+    #[test]
+    fn append_bytes() {
+        // &str
+        let data = Anything::new().append_bytes(2, "testing");
+        assert_eq!(
+            data.into_vec(),
+            [0x12, 0x07, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67]
+        );
+
+        // String
+        let data = Anything::new().append_bytes(2, String::from("testing"));
+        assert_eq!(
+            data.into_vec(),
+            [0x12, 0x07, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67]
+        );
+
+        // &[u8]
+        let data = Anything::new().append_bytes(2, b"testing");
+        assert_eq!(
+            data.into_vec(),
+            [0x12, 0x07, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67]
+        );
+
+        // Empty field not written
+        let data = Anything::new().append_bytes(2, b"");
+        assert_eq!(data.into_vec(), []);
+    }
+}

--- a/packages/anything/tests.proto
+++ b/packages/anything/tests.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+message Lights {
+  bool on = 3;
+}
+
+message Room {
+  uint32 number = 1;
+  Lights lights = 2;
+  uint64 size = 3;
+}

--- a/packages/multitest/tests/drand-gateway.rs
+++ b/packages/multitest/tests/drand-gateway.rs
@@ -5,7 +5,6 @@ use cw_multi_test::{AppBuilder, ContractWrapper, Executor, StakingInfo};
 use nois_multitest::{first_attr, mint_native, query_balance_native};
 
 const SINK: &str = "sink";
-const COMMUNOTY_POOL: &str = "community_pool";
 
 #[test]
 fn integration_test() {
@@ -103,7 +102,6 @@ fn integration_test() {
                 price: Coin::new(1, "unois"),
                 payment_code_id: code_id_nois_payment,
                 sink: SINK.to_string(),
-                community_pool: COMMUNOTY_POOL.to_string(),
             },
             &[],
             "Nois-Gateway",
@@ -124,7 +122,6 @@ fn integration_test() {
             price: Coin::new(1, "unois"),
             payment_code_id: code_id_nois_payment,
             sink: Addr::unchecked(SINK),
-            community_pool: Addr::unchecked(COMMUNOTY_POOL),
         }
     );
 
@@ -182,7 +179,6 @@ fn integration_test() {
             price: Coin::new(1, "unois"),
             payment_code_id: code_id_nois_payment,
             sink: Addr::unchecked(SINK),
-            community_pool: Addr::unchecked(COMMUNOTY_POOL),
         }
     );
 

--- a/packages/multitest/tests/multitest.rs
+++ b/packages/multitest/tests/multitest.rs
@@ -4,7 +4,6 @@ use nois_multitest::mint_native;
 
 const PAYMENT: u64 = 17;
 const SINK: &str = "sink";
-const COMMUNOTY_POOL: &str = "community_pool";
 
 #[test]
 fn integration_test() {
@@ -55,7 +54,6 @@ fn integration_test() {
                 price: Coin::new(1, "unois"),
                 payment_code_id: PAYMENT,
                 sink: SINK.to_string(),
-                community_pool: COMMUNOTY_POOL.to_string(),
             },
             &[],
             "Nois-Gateway",
@@ -76,7 +74,6 @@ fn integration_test() {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: Addr::unchecked(SINK),
-            community_pool: Addr::unchecked(COMMUNOTY_POOL),
         }
     );
 
@@ -111,7 +108,6 @@ fn integration_test() {
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
             sink: Addr::unchecked(SINK),
-            community_pool: Addr::unchecked(COMMUNOTY_POOL),
         }
     );
 

--- a/tests/src/contracts.ts
+++ b/tests/src/contracts.ts
@@ -49,8 +49,6 @@ export interface GatewayInstantiateMsg {
   readonly payment_code_id: number;
   /** Address of the Nois sink */
   readonly sink: string;
-  /** Address of the Nois community pool */
-  readonly community_pool: string;
 }
 
 export interface GatewayExecuteMsg {

--- a/tests/src/tests.spec.ts
+++ b/tests/src/tests.spec.ts
@@ -78,7 +78,6 @@ test.serial("set up channel", async (t) => {
     price: coin(0, "unois"),
     payment_code_id: context.noisCodeIds.payment,
     sink: "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt",
-    community_pool: "nois1uw8c69maprjq5ure7x80x9nauasrn7why5dfwd",
   };
   const { contractAddress: gatewayAddress } = await noisClient.sign.instantiate(
     noisClient.senderAddress,
@@ -153,7 +152,6 @@ async function instantiateAndConnectIbc(
     price: coin(0, "unois"),
     payment_code_id: context.noisCodeIds.payment,
     sink: "nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt",
-    community_pool: "nois1uw8c69maprjq5ure7x80x9nauasrn7why5dfwd",
   };
   const { contractAddress: noisGatewayAddress } = await noisClient.sign.instantiate(
     noisClient.senderAddress,


### PR DESCRIPTION
This PR shows how we can use proto encoded Stargate messages to create a MsgFundCommunityPool