### PR TITLE
Gateway log processed requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to
 - proxy: Streamline event attributes
 - proxy: Add `min_after`/`max_after` configs in proxy to ensure the `after`
   value for RequestBeacon packets is in a somewhat reasonable range.
-- gateway: Write a list of beacon requests per customer to state to be able to
+- gateway: Write a log of beacon requests per customer to state to be able to
   query them later on ([#250]).
 
 [#250]: https://github.com/noislabs/nois-contracts/pull/250

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - proxy: Streamline event attributes
 - proxy: Add `min_after`/`max_after` configs in proxy to ensure the `after`
   value for RequestBeacon packets is in a somewhat reasonable range.
+- gateway: Write a list of beacon requests per customer to state to be able to
+  query them later on ([#250]).
+
+[#250]: https://github.com/noislabs/nois-contracts/pull/250
 
 ## [0.13.4] - 2023-05-17
 

--- a/contracts/nois-gateway/src/msg.rs
+++ b/contracts/nois-gateway/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Coin, HexBinary};
 
-use crate::state::{Config, Customer};
+use crate::state::{Config, Customer, ProcessedRequest};
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -54,6 +54,18 @@ pub enum QueryMsg {
         start_after: Option<String>,
         limit: Option<u32>,
     },
+    #[returns(RequestsResponse)]
+    RequestsAsc {
+        channel_id: String,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    },
+    #[returns(RequestsResponse)]
+    RequestsDesc {
+        channel_id: String,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    },
 }
 
 // We define a custom struct for each query response
@@ -96,4 +108,9 @@ pub struct CustomerResponse {
 #[cw_serde]
 pub struct CustomersResponse {
     pub customers: Vec<QueriedCustomer>,
+}
+
+#[cw_serde]
+pub struct RequestsResponse {
+    pub requests: Vec<ProcessedRequest>,
 }

--- a/contracts/nois-gateway/src/msg.rs
+++ b/contracts/nois-gateway/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Coin, HexBinary};
 
-use crate::state::{Config, Customer, ProcessedRequest};
+use crate::state::{Config, Customer, RequestLogEntry};
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -54,14 +54,14 @@ pub enum QueryMsg {
         start_after: Option<String>,
         limit: Option<u32>,
     },
-    #[returns(RequestsResponse)]
-    RequestsAsc {
+    #[returns(RequestsLogResponse)]
+    RequestsLogAsc {
         channel_id: String,
         offset: Option<u32>,
         limit: Option<u32>,
     },
-    #[returns(RequestsResponse)]
-    RequestsDesc {
+    #[returns(RequestsLogResponse)]
+    RequestsLogDesc {
         channel_id: String,
         offset: Option<u32>,
         limit: Option<u32>,
@@ -111,6 +111,6 @@ pub struct CustomersResponse {
 }
 
 #[cw_serde]
-pub struct RequestsResponse {
-    pub requests: Vec<ProcessedRequest>,
+pub struct RequestsLogResponse {
+    pub requests: Vec<RequestLogEntry>,
 }

--- a/contracts/nois-gateway/src/state.rs
+++ b/contracts/nois-gateway/src/state.rs
@@ -117,6 +117,35 @@ pub fn requests_add(
     Deque::new(&prefix).push_back(storage, request)
 }
 
+pub fn requests_get_asc(
+    storage: &dyn Storage,
+    channel_id: &str,
+    offset: usize,
+    limit: usize,
+) -> StdResult<Vec<ProcessedRequest>> {
+    let prefix = requests_key(channel_id);
+    Deque::new(&prefix)
+        .iter(storage)?
+        .skip(offset)
+        .take(limit)
+        .collect()
+}
+
+pub fn requests_get_desc(
+    storage: &dyn Storage,
+    channel_id: &str,
+    offset: usize,
+    limit: usize,
+) -> StdResult<Vec<ProcessedRequest>> {
+    let prefix = requests_key(channel_id);
+    Deque::new(&prefix)
+        .iter(storage)?
+        .rev()
+        .skip(offset)
+        .take(limit)
+        .collect()
+}
+
 #[inline]
 fn requests_key(channel_id: &str) -> String {
     format!("r_{channel_id}")


### PR DESCRIPTION
This allows querying all requests a gateway ever did. For the pingpong we can observe the latest 5 or 10 request using  the desc quey to find the info we care about.