### PR TITLE
Add trusted sources config to gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to
   only use those. This allows bots to submit other rounds for no reason.
 - gateway: Remove `ExecuteMsg::Cleanup` to cleanup outdated jobs state ([#280])
 - gateway: Remove code for accessing drand jobs storage layout v1 ([#280])
+- gateway: Create trusted source configuration to improve testability ([#271])
 
+[#271]: https://github.com/noislabs/nois-contracts/pull/271
 [#280]: https://github.com/noislabs/nois-contracts/pull/280
 
 ### Fixed

--- a/contracts/nois-gateway/src/attributes.rs
+++ b/contracts/nois-gateway/src/attributes.rs
@@ -1,0 +1,6 @@
+//! Stable event attributes
+//!
+//! The attributes here should only be changed very carefully as it is likely that clients rely on them.
+
+/// Which entry point/message type was executed
+pub const ATTR_ACTION: &str = "action";

--- a/contracts/nois-gateway/src/lib.rs
+++ b/contracts/nois-gateway/src/lib.rs
@@ -1,3 +1,4 @@
+mod attributes;
 mod drand_archive;
 mod job_id;
 mod request_router;

--- a/contracts/nois-gateway/src/msg.rs
+++ b/contracts/nois-gateway/src/msg.rs
@@ -34,6 +34,7 @@ pub enum ExecuteMsg {
         /// See https://twitter.com/simon_warta/status/1643354582494642177 for why.
         /// To deactivate it later on, send Some(Coin::new(0, "unois")) here.
         payment_initial_funds: Option<Coin>,
+        trusted_sources: Option<Vec<String>>,
     },
 }
 

--- a/contracts/nois-gateway/src/state/config.rs
+++ b/contracts/nois-gateway/src/state/config.rs
@@ -5,8 +5,11 @@ use cw_storage_plus::Item;
 #[cw_serde]
 pub struct Config {
     /// The address of the drand contract.
-    /// As long as this is unset, noone can submit randomness.
     pub drand: Option<Addr>,
+    /// Addresses which are trusted for providing randomness to the gateway.
+    /// None and an empty vector means the same. This is just an Option for compatibility
+    /// with previous versions of the contract.
+    pub trusted_sources: Option<Vec<Addr>>,
     /// Manager to set the price and drand address
     pub manager: Addr,
     /// The price to pay in order to register the randomness job

--- a/packages/multitest/tests/drand-gateway.rs
+++ b/packages/multitest/tests/drand-gateway.rs
@@ -121,6 +121,7 @@ fn integration_test() {
         resp,
         nois_gateway::msg::ConfigResponse {
             drand: None,
+            trusted_sources: None,
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
             payment_code_id: code_id_nois_payment,
@@ -166,6 +167,7 @@ fn integration_test() {
             manager: None,
             price: None,
             drand_addr: Some(addr_nois_drand.to_string()),
+            trusted_sources: Some(vec![addr_nois_drand.to_string()]),
             payment_initial_funds: None,
         },
         &[],
@@ -179,6 +181,7 @@ fn integration_test() {
         resp,
         nois_gateway::msg::ConfigResponse {
             drand: Some(addr_nois_drand.clone()),
+            trusted_sources: Some(vec![addr_nois_drand.clone()]),
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
             payment_code_id: code_id_nois_payment,

--- a/packages/multitest/tests/multitest.rs
+++ b/packages/multitest/tests/multitest.rs
@@ -73,6 +73,7 @@ fn integration_test() {
         resp,
         nois_gateway::msg::ConfigResponse {
             drand: None,
+            trusted_sources: None,
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
@@ -88,6 +89,7 @@ fn integration_test() {
         manager: None,
         price: None,
         drand_addr: Some(DRAND.to_string()),
+        trusted_sources: Some(vec![DRAND.to_string()]),
         payment_initial_funds: None,
     };
     let _resp = app
@@ -108,6 +110,7 @@ fn integration_test() {
         resp,
         nois_gateway::msg::ConfigResponse {
             drand: Some(Addr::unchecked(DRAND)),
+            trusted_sources: Some(vec![Addr::unchecked(DRAND)]),
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,

--- a/packages/multitest/tests/proxy-governance-owned.rs
+++ b/packages/multitest/tests/proxy-governance-owned.rs
@@ -73,6 +73,7 @@ fn integration_test() {
         resp,
         nois_gateway::msg::ConfigResponse {
             drand: None,
+            trusted_sources: None,
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,
@@ -88,6 +89,7 @@ fn integration_test() {
         manager: None,
         price: None,
         drand_addr: Some(DRAND.to_string()),
+        trusted_sources: Some(vec![DRAND.to_string()]),
         payment_initial_funds: None,
     };
     let _resp = app
@@ -108,6 +110,7 @@ fn integration_test() {
         resp,
         nois_gateway::msg::ConfigResponse {
             drand: Some(Addr::unchecked(DRAND)),
+            trusted_sources: Some(vec![Addr::unchecked(DRAND)]),
             manager: Addr::unchecked("manager"),
             price: Coin::new(1, "unois"),
             payment_code_id: PAYMENT,

--- a/tests/src/contracts.ts
+++ b/tests/src/contracts.ts
@@ -67,6 +67,7 @@ export interface GatewayExecuteMsg {
     readonly price?: null | Coin;
     readonly drand_addr?: null | string;
     readonly payment_initial_funds?: null | Coin;
+    readonly trusted_sources?: null | string[];
   };
 }
 

--- a/tests/src/setup.ts
+++ b/tests/src/setup.ts
@@ -168,8 +168,8 @@ export async function instantiateAndConnectIbc(
   }
 
   if (options.mockDrandAddr) {
-    const setDrandMsg: GatewayExecuteMsg = { set_config: { drand_addr: options.mockDrandAddr } };
-    await noisClient.sign.execute(noisClient.senderAddress, noisGatewayAddress, setDrandMsg, "auto");
+    const setConfigMsg: GatewayExecuteMsg = { set_config: { trusted_sources: [options.mockDrandAddr] } };
+    await noisClient.sign.execute(noisClient.senderAddress, noisGatewayAddress, setConfigMsg, "auto");
   }
 
   const [noisProxyInfo, noisGatewayInfo] = await Promise.all([


### PR DESCRIPTION
This splits the drand and trusted sources config in the gateway in order to be able to set tusted sources for testing without setting the drand contract. This is needed for #266 such that tests receive randomness from the testing framework but do not send messages to the non-existent drand contract.