### PR TITLE
add-relayer-comission-to-compensate-for-gas

### DIFF
--- a/contracts/nois-gateway/src/contract.rs
+++ b/contracts/nois-gateway/src/contract.rs
@@ -426,9 +426,9 @@ fn receive_request_beacon(
     let config = CONFIG.load(deps.storage)?;
 
     let Coin { amount, denom } = config.price;
-    let amount_burn = amount.mul_floor((50u128, 100)); // 50%
-    let amount_relayer = amount.mul_floor((5u128, 100)); // 5%
-    let amount_rest = amount - amount_burn - amount_relayer; // 45%
+    let amount_burn = amount.mul_floor((40u128, 100)); // 40%
+    let amount_relayer = amount.mul_floor((20u128, 100)); // 20%
+    let amount_rest = amount - amount_burn - amount_relayer; // 40%
 
     let msg = WasmMsg::Execute {
         contract_addr: customer.payment.into(),

--- a/tests/src/payment.spec.ts
+++ b/tests/src/payment.spec.ts
@@ -173,9 +173,10 @@ test.serial("payment works for ibc_pay mode", async (t) => {
   bot.setGatewayAddress(noisGatewayAddress);
 
   const gatewayPrice = 50_000000; // the gateway `price`
-  const burnAmount = 0.5 * gatewayPrice; // 50% of the gateway `price`
-  const poolAmount = 0.45 * gatewayPrice; // 45% of the gateway `price`
-  const relayerAmount = 0.05 * gatewayPrice; // 5% of the gateway `price`
+  const burnAmount = 0.4 * gatewayPrice; // 40% of the gateway `price`
+  const poolAmount = 0.4 * gatewayPrice; // 40% of the gateway `price`
+  const relayerAmount = 0.2 * gatewayPrice; // 20% of the gateway `price`
+
 
   const { customer }: GatewayCustomerResponse = await noisClient.sign.queryContractSmart(noisGatewayAddress, {
     customer: { channel_id: noisChannel.noisChannelId },

--- a/tests/src/payment.spec.ts
+++ b/tests/src/payment.spec.ts
@@ -49,9 +49,9 @@ test.serial("payment works for funded mode", async (t) => {
   bot.setGatewayAddress(noisGatewayAddress);
 
   const gatewayPrice = 50_000000; // the gateway `price`
-  const burnAmount = 0.5 * gatewayPrice; // 50% of the gateway `price`
-  const poolAmount = 0.45 * gatewayPrice; // 45% of the gateway `price`
-  const relayerAmount = 0.05 * gatewayPrice; // 5% of the gateway `price`
+  const burnAmount = 0.4 * gatewayPrice; // 40% of the gateway `price`
+  const poolAmount = 0.4 * gatewayPrice; // 40% of the gateway `price`
+  const relayerAmount = 0.2 * gatewayPrice; // 20% of the gateway `price`
 
   const { customer }: GatewayCustomerResponse = await noisClient.sign.queryContractSmart(noisGatewayAddress, {
     customer: { channel_id: noisChannel.noisChannelId },

--- a/tests/src/payment.spec.ts
+++ b/tests/src/payment.spec.ts
@@ -177,7 +177,6 @@ test.serial("payment works for ibc_pay mode", async (t) => {
   const poolAmount = 0.4 * gatewayPrice; // 40% of the gateway `price`
   const relayerAmount = 0.2 * gatewayPrice; // 20% of the gateway `price`
 
-
   const { customer }: GatewayCustomerResponse = await noisClient.sign.queryContractSmart(noisGatewayAddress, {
     customer: { channel_id: noisChannel.noisChannelId },
   });


### PR DESCRIPTION
### Context: 
After reducing the price of the beacon to 1NOIS, relayers aren't profitable anymore.
The IBC receive costs 0.09 NOIS, but there are also other messages to relay like the ACK or some ICS20 traffic.
### Solution:
One solution is to change the ratio so that relayers don't lose anymore at least onthe nois side of the bridge. 
This could also be set in the contract state in the config struct instead of hardcoded. 
