### PR TITLE
Upgrade multitest to version v2.1.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "2.0.1"
+version = "2.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e403ad6ec62c8bcbcb75f7f4940712d0142b6103310da2a9375252b942358caa"
+checksum = "3dda4f946ada926f7ac2b3c1373c44cdc70bd231c2092afd8d94c4cef1c3b332"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
@@ -253,7 +253,7 @@ dependencies = [
  "cw-storage-plus",
  "cw-utils",
  "derivative",
- "itertools",
+ "itertools 0.13.0",
  "prost",
  "schemars",
  "serde",
@@ -505,6 +505,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -766,7 +775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.66",

--- a/contracts/nois-drand/src/state.rs
+++ b/contracts/nois-drand/src/state.rs
@@ -14,7 +14,7 @@ pub enum TopKey {
 
 impl TopKey {
     const fn as_str(&self) -> &str {
-        let data = unsafe { std::mem::transmute::<_, &[u8; 1]>(self) };
+        let data = unsafe { std::mem::transmute::<&Self, &[u8; 1]>(self) };
         match std::str::from_utf8(data) {
             Ok(a) => a,
             Err(_) => panic!("Non-utf8 enum value found. Use a-z, A-Z and 0-9"),

--- a/packages/multitest/Cargo.toml
+++ b/packages/multitest/Cargo.toml
@@ -14,14 +14,14 @@ crate-type = ["cdylib", "rlib"]
 [features]
 
 [dependencies]
-nois-drand = { path = "../../contracts/nois-drand"}
-nois-gateway = { path = "../../contracts/nois-gateway"}
-nois-icecube = { path = "../../contracts/nois-icecube"}
+nois-drand = { path = "../../contracts/nois-drand" }
+nois-gateway = { path = "../../contracts/nois-gateway" }
+nois-icecube = { path = "../../contracts/nois-icecube" }
 nois-payment = { path = "../../contracts/nois-payment" }
 nois-proxy = { path = "../../contracts/nois-proxy" }
 nois-proxy-governance-owned = { path = "../../contracts/nois-proxy-governance-owned" }
 
-cosmwasm-std = { version = "2.0.4", features = ["iterator"] }
-cw-multi-test = "2"
+cosmwasm-std = "2.0.4"
+cw-multi-test = { version = "2.1.0-rc.1", features = ["staking", "cosmwasm_2_0"] }
 
 [dev-dependencies]

--- a/packages/multitest/src/lib.rs
+++ b/packages/multitest/src/lib.rs
@@ -1,15 +1,10 @@
 // Testing utils. See tests folder for actual tests.
 
-use cosmwasm_std::testing::MockApi;
 use cosmwasm_std::{
     coin, from_json, to_json_binary, Addr, Attribute, BalanceResponse, BankQuery, Coin, Querier,
     QueryRequest,
 };
 use cw_multi_test::App;
-
-pub fn addr(input: &str) -> Addr {
-    MockApi::default().addr_make(input)
-}
 
 /// Gets the value of the first attribute with the given key
 pub fn first_attr(data: impl AsRef<[Attribute]>, search_key: &str) -> Option<String> {

--- a/packages/multitest/tests/drand-gateway.rs
+++ b/packages/multitest/tests/drand-gateway.rs
@@ -1,8 +1,8 @@
 // Testing nois-drand and nois-gateway interaction
 
 use cosmwasm_std::{coin, testing::mock_env, Decimal, HexBinary, Timestamp, Uint128, Validator};
-use cw_multi_test::{AppBuilder, ContractWrapper, Executor, StakingInfo};
-use nois_multitest::{addr, first_attr, mint_native, payment_initial, query_balance_native};
+use cw_multi_test::{AppBuilder, ContractWrapper, Executor, IntoBech32, StakingInfo};
+use nois_multitest::{first_attr, mint_native, payment_initial, query_balance_native};
 
 #[test]
 fn integration_test() {
@@ -20,7 +20,9 @@ fn integration_test() {
             )
             .unwrap();
         let valoper1 = Validator::new(
-            addr("noislabs").to_string(), // TODO: this should not be an account address
+            "noislabs"
+                .into_bech32_with_prefix("noisevaloper")
+                .to_string(),
             Decimal::percent(1),
             Decimal::percent(100),
             Decimal::percent(1),
@@ -32,10 +34,10 @@ fn integration_test() {
             .unwrap();
     });
 
-    let owner = addr("owner");
-    let bossman = addr("bossman");
-    let manager = addr("manager");
-    let sink = addr("sink");
+    let owner = app.api().addr_make("owner");
+    let bossman = app.api().addr_make("bossman");
+    let manager = app.api().addr_make("manager");
+    let sink = app.api().addr_make("sink");
 
     // Mint 1000 NOIS for owner
     mint_native(&mut app, &owner, "unois", 1_000_000_000);
@@ -244,15 +246,15 @@ fn integration_test() {
         }
     );
 
-    let bot1 = addr("drand_bot_1");
-    let bot2 = addr("drand_bot_two");
-    let bot3 = addr("drand_bot_three33333");
-    let bot4 = addr("drand_bot_4");
-    let bot5 = addr("drand_bot_5");
-    let bot6 = addr("drand_bot_six_");
-    let bot7 = addr("drand_bot_7");
-    let bot8 = addr("drand_bot_8");
-    let new_bot = addr("new_bot");
+    let bot1 = app.api().addr_make("drand_bot_1");
+    let bot2 = app.api().addr_make("drand_bot_two");
+    let bot3 = app.api().addr_make("drand_bot_three33333");
+    let bot4 = app.api().addr_make("drand_bot_4");
+    let bot5 = app.api().addr_make("drand_bot_5");
+    let bot6 = app.api().addr_make("drand_bot_six_");
+    let bot7 = app.api().addr_make("drand_bot_7");
+    let bot8 = app.api().addr_make("drand_bot_8");
+    let new_bot = app.api().addr_make("new_bot");
 
     // register bots
     let msg = nois_drand::msg::ExecuteMsg::RegisterBot {

--- a/packages/multitest/tests/drand-gateway.rs
+++ b/packages/multitest/tests/drand-gateway.rs
@@ -35,7 +35,7 @@ fn integration_test() {
     });
 
     let owner = app.api().addr_make("owner");
-    let bosman = app.api().addr_make("bosman");
+    let bossman = app.api().addr_make("bossman");
     let manager = app.api().addr_make("manager");
     let sink = app.api().addr_make("sink");
 
@@ -56,7 +56,7 @@ fn integration_test() {
             code_id_nois_drand,
             owner.clone(),
             &nois_drand::msg::InstantiateMsg {
-                manager: bosman.to_string(),
+                manager: bossman.to_string(),
                 incentive_point_price: Uint128::new(1_500),
                 incentive_denom: "unois".to_string(),
                 min_round: 0,
@@ -73,7 +73,7 @@ fn integration_test() {
     assert_eq!(
         resp,
         nois_drand::msg::ConfigResponse {
-            manager: bosman.clone(),
+            manager: bossman.clone(),
             gateway: None,
             min_round: 0,
             incentive_point_price: Uint128::new(1_500),
@@ -135,7 +135,7 @@ fn integration_test() {
 
     // Set gateway address to drand
     app.execute_contract(
-        bosman.clone(),
+        bossman.clone(),
         addr_nois_drand.to_owned(),
         &nois_drand::msg::ExecuteMsg::SetConfig {
             manager: None,
@@ -154,7 +154,7 @@ fn integration_test() {
     assert_eq!(
         resp,
         nois_drand::msg::ConfigResponse {
-            manager: bosman.clone(),
+            manager: bossman.clone(),
             gateway: Some(addr_nois_gateway.clone()),
             min_round: 0,
             incentive_point_price: Uint128::new(1_500),
@@ -333,7 +333,7 @@ fn integration_test() {
         ],
         remove: vec![],
     };
-    app.execute_contract(bosman.clone(), addr_nois_drand.to_owned(), &msg, &[])
+    app.execute_contract(bossman.clone(), addr_nois_drand.to_owned(), &msg, &[])
         .unwrap();
 
     // Add round

--- a/packages/multitest/tests/drand-gateway.rs
+++ b/packages/multitest/tests/drand-gateway.rs
@@ -1,13 +1,13 @@
 // Testing nois-drand and nois-gateway interaction
 
 use cosmwasm_std::{coin, testing::mock_env, Decimal, HexBinary, Timestamp, Uint128, Validator};
-use cw_multi_test::{AppBuilder, ContractWrapper, Executor, IntoBech32, StakingInfo};
+use cw_multi_test::{App, ContractWrapper, Executor, IntoBech32, StakingInfo};
 use nois_multitest::{first_attr, mint_native, payment_initial, query_balance_native};
 
 #[test]
 fn integration_test() {
-    // Insantiate a chain mock environment
-    let mut app = AppBuilder::new().build(|router, api, storage| {
+    // Instantiate a chain mock environment
+    let mut app = App::new(|router, api, storage| {
         router
             .staking
             .setup(
@@ -35,7 +35,7 @@ fn integration_test() {
     });
 
     let owner = app.api().addr_make("owner");
-    let bossman = app.api().addr_make("bossman");
+    let bosman = app.api().addr_make("bosman");
     let manager = app.api().addr_make("manager");
     let sink = app.api().addr_make("sink");
 
@@ -56,7 +56,7 @@ fn integration_test() {
             code_id_nois_drand,
             owner.clone(),
             &nois_drand::msg::InstantiateMsg {
-                manager: bossman.to_string(),
+                manager: bosman.to_string(),
                 incentive_point_price: Uint128::new(1_500),
                 incentive_denom: "unois".to_string(),
                 min_round: 0,
@@ -73,7 +73,7 @@ fn integration_test() {
     assert_eq!(
         resp,
         nois_drand::msg::ConfigResponse {
-            manager: bossman.clone(),
+            manager: bosman.clone(),
             gateway: None,
             min_round: 0,
             incentive_point_price: Uint128::new(1_500),
@@ -135,7 +135,7 @@ fn integration_test() {
 
     // Set gateway address to drand
     app.execute_contract(
-        bossman.clone(),
+        bosman.clone(),
         addr_nois_drand.to_owned(),
         &nois_drand::msg::ExecuteMsg::SetConfig {
             manager: None,
@@ -154,7 +154,7 @@ fn integration_test() {
     assert_eq!(
         resp,
         nois_drand::msg::ConfigResponse {
-            manager: bossman.clone(),
+            manager: bosman.clone(),
             gateway: Some(addr_nois_gateway.clone()),
             min_round: 0,
             incentive_point_price: Uint128::new(1_500),
@@ -333,7 +333,7 @@ fn integration_test() {
         ],
         remove: vec![],
     };
-    app.execute_contract(bossman.clone(), addr_nois_drand.to_owned(), &msg, &[])
+    app.execute_contract(bosman.clone(), addr_nois_drand.to_owned(), &msg, &[])
         .unwrap();
 
     // Add round
@@ -463,7 +463,7 @@ fn integration_test() {
         .unwrap();
 
     let wasm = resp.events.iter().find(|ev| ev.ty == "wasm").unwrap();
-    // Make sure that there is no incentive for this bot because it didn't do the verification and it was slow
+    // Make sure that there is no incentive for this bot because it didn't do the verification, and it was slow
     // i.e. enough drandbots have already verified this round.
     assert_eq!(first_attr(&wasm.attributes, "reward_points").unwrap(), "0");
     assert_eq!(
@@ -471,7 +471,7 @@ fn integration_test() {
         "0unois"
     );
 
-    // Add round 8th submission: invalid siganture
+    // Add round 8th submission: invalid signature
     //
     // Check that when a submission has been verified in previous txs by enough other bots
     // and when a new bot brings a submission that won't go through verification. It should fail if it

--- a/packages/multitest/tests/drand-gateway.rs
+++ b/packages/multitest/tests/drand-gateway.rs
@@ -21,7 +21,7 @@ fn integration_test() {
             .unwrap();
         let valoper1 = Validator::new(
             "noislabs"
-                .into_bech32_with_prefix("noisevaloper")
+                .into_bech32_with_prefix("noisvaloper")
                 .to_string(),
             Decimal::percent(1),
             Decimal::percent(100),

--- a/packages/multitest/tests/icecube.rs
+++ b/packages/multitest/tests/icecube.rs
@@ -1,8 +1,8 @@
 use cosmwasm_std::{
     coin, testing::mock_env, Addr, BlockInfo, Decimal, Delegation, Uint128, Validator,
 };
-use cw_multi_test::{AppBuilder, ContractWrapper, Executor, StakingInfo};
-use nois_multitest::{addr, first_attr, mint_native, query_balance_native};
+use cw_multi_test::{AppBuilder, ContractWrapper, Executor, IntoBech32, StakingInfo};
+use nois_multitest::{first_attr, mint_native, query_balance_native};
 
 #[test]
 fn integration_test() {
@@ -20,7 +20,9 @@ fn integration_test() {
             )
             .unwrap();
         let valoper1 = Validator::new(
-            addr("noislabs").to_string(), // TODO: this should not be an account address
+            "noislabs"
+                .into_bech32_with_prefix("noisevaloper")
+                .to_string(),
             Decimal::percent(1),
             Decimal::percent(100),
             Decimal::percent(1),
@@ -32,8 +34,8 @@ fn integration_test() {
             .unwrap();
     });
 
-    let owner = addr("owner");
-    let bossman = addr("bossman");
+    let owner = app.api().addr_make("owner");
+    let bossman = app.api().addr_make("bossman");
 
     // Storing nois-drand code
     let code_nois_drand = ContractWrapper::new(
@@ -166,7 +168,9 @@ fn integration_test() {
 
     // Make nois-icecube delegate
     let msg = nois_icecube::msg::ExecuteMsg::Delegate {
-        addr: addr("noislabs").to_string(), // TODO: this should not be an account address
+        addr: "noislabs"
+            .into_bech32_with_prefix("noisevaloper")
+            .to_string(),
         amount: Uint128::new(500_000),
     };
     app.execute_contract(bossman.clone(), addr_nois_icecube.to_owned(), &msg, &[])
@@ -184,7 +188,9 @@ fn integration_test() {
             .unwrap()[0],
         Delegation::new(
             addr_nois_icecube.clone(),
-            addr("noislabs").to_string(), // TODO: this should not be an account address
+            "noislabs"
+                .into_bech32_with_prefix("noisevaloper")
+                .to_string(),
             coin(500_000, "unois"),
         )
     );
@@ -200,7 +206,9 @@ fn integration_test() {
 
     // Make nois-icecube claim
     let msg = nois_icecube::msg::ExecuteMsg::ClaimRewards {
-        addr: addr("noislabs").to_string(), // TODO: this should not be an account address
+        addr: "noislabs"
+            .into_bech32_with_prefix("noisevaloper")
+            .to_string(),
     };
     let resp = app
         .execute_contract(owner.clone(), addr_nois_icecube, &msg, &[])

--- a/packages/multitest/tests/icecube.rs
+++ b/packages/multitest/tests/icecube.rs
@@ -21,7 +21,7 @@ fn integration_test() {
             .unwrap();
         let valoper1 = Validator::new(
             "noislabs"
-                .into_bech32_with_prefix("noisevaloper")
+                .into_bech32_with_prefix("noisvaloper")
                 .to_string(),
             Decimal::percent(1),
             Decimal::percent(100),
@@ -169,7 +169,7 @@ fn integration_test() {
     // Make nois-icecube delegate
     let msg = nois_icecube::msg::ExecuteMsg::Delegate {
         addr: "noislabs"
-            .into_bech32_with_prefix("noisevaloper")
+            .into_bech32_with_prefix("noisvaloper")
             .to_string(),
         amount: Uint128::new(500_000),
     };
@@ -189,7 +189,7 @@ fn integration_test() {
         Delegation::new(
             addr_nois_icecube.clone(),
             "noislabs"
-                .into_bech32_with_prefix("noisevaloper")
+                .into_bech32_with_prefix("noisvaloper")
                 .to_string(),
             coin(500_000, "unois"),
         )
@@ -207,7 +207,7 @@ fn integration_test() {
     // Make nois-icecube claim
     let msg = nois_icecube::msg::ExecuteMsg::ClaimRewards {
         addr: "noislabs"
-            .into_bech32_with_prefix("noisevaloper")
+            .into_bech32_with_prefix("noisvaloper")
             .to_string(),
     };
     let resp = app

--- a/packages/multitest/tests/icecube.rs
+++ b/packages/multitest/tests/icecube.rs
@@ -35,7 +35,7 @@ fn integration_test() {
     });
 
     let owner = app.api().addr_make("owner");
-    let bosman = app.api().addr_make("bosman");
+    let bossman = app.api().addr_make("bossman");
 
     // Storing nois-drand code
     let code_nois_drand = ContractWrapper::new(
@@ -51,7 +51,7 @@ fn integration_test() {
             code_id_nois_drand,
             owner.clone(),
             &nois_drand::msg::InstantiateMsg {
-                manager: bosman.to_string(),
+                manager: bossman.to_string(),
                 incentive_point_price: Uint128::new(20_000),
                 incentive_denom: "unois".to_string(),
                 min_round: 0,
@@ -79,7 +79,7 @@ fn integration_test() {
             code_id_nois_icecube,
             owner.clone(),
             &nois_icecube::msg::InstantiateMsg {
-                manager: bosman.to_string(),
+                manager: bossman.to_string(),
             },
             &[coin(1_000_000, "unois")],
             "Nois-Icecube",
@@ -95,7 +95,7 @@ fn integration_test() {
     assert_eq!(
         resp,
         nois_icecube::msg::ConfigResponse {
-            manager: bosman.clone(),
+            manager: bossman.clone(),
             drand: None,
         }
     );
@@ -121,7 +121,7 @@ fn integration_test() {
     ));
 
     let resp = app
-        .execute_contract(bosman.clone(), addr_nois_icecube.to_owned(), &msg, &[])
+        .execute_contract(bossman.clone(), addr_nois_icecube.to_owned(), &msg, &[])
         .unwrap();
     let wasm = resp.events.iter().find(|ev| ev.ty == "wasm").unwrap();
     // Make sure the tx passed
@@ -138,7 +138,7 @@ fn integration_test() {
     assert_eq!(
         resp,
         nois_icecube::msg::ConfigResponse {
-            manager: bosman.clone(),
+            manager: bossman.clone(),
             drand: Some(addr_nois_drand.clone())
         }
     );
@@ -173,7 +173,7 @@ fn integration_test() {
             .to_string(),
         amount: Uint128::new(500_000),
     };
-    app.execute_contract(bosman.clone(), addr_nois_icecube.to_owned(), &msg, &[])
+    app.execute_contract(bossman.clone(), addr_nois_icecube.to_owned(), &msg, &[])
         .unwrap();
     // Check balance nois-icecube
     let balance = query_balance_native(&app, &addr_nois_icecube, "unois").amount;

--- a/packages/multitest/tests/multitest.rs
+++ b/packages/multitest/tests/multitest.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{coin, testing::mock_env, Decimal, HexBinary, Timestamp, Uint128, Validator};
-use cw_multi_test::{AppBuilder, ContractWrapper, Executor, StakingInfo};
-use nois_multitest::{addr, mint_native, payment_initial};
+use cw_multi_test::{AppBuilder, ContractWrapper, Executor, IntoBech32, StakingInfo};
+use nois_multitest::{mint_native, payment_initial};
 
 const PAYMENT: u64 = 17;
 
@@ -20,7 +20,9 @@ fn integration_test() {
             )
             .unwrap();
         let valoper1 = Validator::new(
-            addr("noislabs").to_string(), // TODO: this should not be an account address
+            "noislabs"
+                .into_bech32_with_prefix("noisevaloper")
+                .to_string(),
             Decimal::percent(1),
             Decimal::percent(100),
             Decimal::percent(1),
@@ -32,10 +34,10 @@ fn integration_test() {
             .unwrap();
     });
 
-    let owner = addr("owner");
-    let manager = addr("manager");
-    let sink = addr("sink");
-    let drand = addr("drand_verifier_7");
+    let owner = app.api().addr_make("owner");
+    let manager = app.api().addr_make("manager");
+    let sink = app.api().addr_make("sink");
+    let drand = app.api().addr_make("drand_verifier_7");
 
     //Mint some coins for owner
     mint_native(&mut app, &owner, "unois", 100_000_000);

--- a/packages/multitest/tests/multitest.rs
+++ b/packages/multitest/tests/multitest.rs
@@ -21,7 +21,7 @@ fn integration_test() {
             .unwrap();
         let valoper1 = Validator::new(
             "noislabs"
-                .into_bech32_with_prefix("noisevaloper")
+                .into_bech32_with_prefix("noisvaloper")
                 .to_string(),
             Decimal::percent(1),
             Decimal::percent(100),

--- a/packages/multitest/tests/multitest.rs
+++ b/packages/multitest/tests/multitest.rs
@@ -1,13 +1,13 @@
 use cosmwasm_std::{coin, testing::mock_env, Decimal, HexBinary, Timestamp, Uint128, Validator};
-use cw_multi_test::{AppBuilder, ContractWrapper, Executor, IntoBech32, StakingInfo};
+use cw_multi_test::{App, ContractWrapper, Executor, IntoBech32, StakingInfo};
 use nois_multitest::{mint_native, payment_initial};
 
 const PAYMENT: u64 = 17;
 
 #[test]
 fn integration_test() {
-    // Insantiate a chain mock environment
-    let mut app = AppBuilder::new().build(|router, api, storage| {
+    // Instantiate a chain mock environment
+    let mut app = App::new(|router, api, storage| {
         router
             .staking
             .setup(

--- a/packages/multitest/tests/proxy-governance-owned.rs
+++ b/packages/multitest/tests/proxy-governance-owned.rs
@@ -23,7 +23,7 @@ fn integration_test() {
             .unwrap();
         let valoper1 = Validator::new(
             "noislabs"
-                .into_bech32_with_prefix("noisevaloper")
+                .into_bech32_with_prefix("noisvaloper")
                 .to_string(),
             Decimal::percent(1),
             Decimal::percent(100),

--- a/packages/multitest/tests/proxy-governance-owned.rs
+++ b/packages/multitest/tests/proxy-governance-owned.rs
@@ -1,15 +1,15 @@
 use cosmwasm_std::{
     coin, testing::mock_env, Addr, Decimal, HexBinary, Timestamp, Uint128, Validator,
 };
-use cw_multi_test::{AppBuilder, ContractWrapper, Executor, IntoBech32, StakingInfo};
+use cw_multi_test::{App, ContractWrapper, Executor, IntoBech32, StakingInfo};
 use nois_multitest::{mint_native, payment_initial};
 
 const PAYMENT: u64 = 17;
 
 #[test]
 fn integration_test() {
-    // Insantiate a chain mock environment
-    let mut app = AppBuilder::new().build(|router, api, storage| {
+    // Instantiate a chain mock environment
+    let mut app = App::new(|router, api, storage| {
         router
             .staking
             .setup(
@@ -41,7 +41,7 @@ fn integration_test() {
     let sink = app.api().addr_make("sink");
     let drand = app.api().addr_make("drand_verifier_7");
 
-    //Mint some coins for owner
+    // Mint some coins for owner
     mint_native(&mut app, &owner, "unois", 100_000_000);
 
     // Storing nois-gateway code

--- a/packages/multitest/tests/proxy-governance-owned.rs
+++ b/packages/multitest/tests/proxy-governance-owned.rs
@@ -1,8 +1,8 @@
 use cosmwasm_std::{
     coin, testing::mock_env, Addr, Decimal, HexBinary, Timestamp, Uint128, Validator,
 };
-use cw_multi_test::{AppBuilder, ContractWrapper, Executor, StakingInfo};
-use nois_multitest::{addr, mint_native, payment_initial};
+use cw_multi_test::{AppBuilder, ContractWrapper, Executor, IntoBech32, StakingInfo};
+use nois_multitest::{mint_native, payment_initial};
 
 const PAYMENT: u64 = 17;
 
@@ -22,7 +22,9 @@ fn integration_test() {
             )
             .unwrap();
         let valoper1 = Validator::new(
-            addr("noislabs").to_string(), // TODO: this should not be an account address
+            "noislabs"
+                .into_bech32_with_prefix("noisevaloper")
+                .to_string(),
             Decimal::percent(1),
             Decimal::percent(100),
             Decimal::percent(1),
@@ -34,10 +36,10 @@ fn integration_test() {
             .unwrap();
     });
 
-    let owner = addr("owner");
-    let manager = addr("manager");
-    let sink = addr("sink");
-    let drand = addr("drand_verifier_7");
+    let owner = app.api().addr_make("owner");
+    let manager = app.api().addr_make("manager");
+    let sink = app.api().addr_make("sink");
+    let drand = app.api().addr_make("drand_verifier_7");
 
     //Mint some coins for owner
     mint_native(&mut app, &owner, "unois", 100_000_000);


### PR DESCRIPTION
- Changed dependency to `cw-multi-test 2.1.0-rc.1`.
- Removed `iterator` from `cosmwasm-std` dependency, because it is a default feature.
- Removed `addr` function in tests and replaced with `app.api().addr_make` as more chain configuration agnostic.
- Refactored validator address generation, this way, that the validators' prefix is different from users' prefix.
- Fixed some typos.
- Fixed one clippy warning.